### PR TITLE
Fix bug 971878 - Add Preset Makerstrap templates

### DIFF
--- a/views/userbar.html
+++ b/views/userbar.html
@@ -13,6 +13,7 @@
           <a class="butter-btn btn-white butter-project-menu-control butter-btn-menu-control"><span class="icon icon-only icon-reorder"></span></a>
           <ul class="butter-btn-menu">
             <li><a href="/{{localeInfo.lang}}/" target="_blank"> <span class="icon icon-file-alt"></span> {{ gettext("New") }}</a></li>
+            <li><a href="https://thimble.webmaker.org/en-US/project/48202/edit" target="_blank"> <span class="icon icon-file-alt"></span> {{ gettext("New From Template") }}</a></li>
             <li><a href="https://support.mozilla.org/{{localeInfo.lang}}/products/webmaker/thimble/" target="_blank"> <span class="icon icon-info"></span> {{ gettext("Help") }}</a></li>
           </ul>
         </div>


### PR DESCRIPTION
Added a button named "New from template" and when the user selects it, it links to a bunch of makerstrap templates. 