### PR TITLE
Bug 1074987 - Simplest way to start w/ tutorial pane expanded.

### DIFF
--- a/public/scripts/tutorials.js
+++ b/public/scripts/tutorials.js
@@ -199,7 +199,7 @@ define(["jquery", "/external/make-api.js", "/external/requestAnimationFrameShim.
           resizeButton.click(function(){
             $("body").toggleClass('tutorial-large');
             $(".icon-resize-full, .icon-resize-small").toggleClass("icon-resize-full icon-resize-small");
-          });
+          }).click();
 
           showButton.click(function() {
             $("body").addClass("tutorial");


### PR DESCRIPTION
Note this might not be the cleanest way to implement [bug 1074987](https://bugzilla.mozilla.org/show_bug.cgi?id=1074987), it was just the most expedient. Any suggestions are appreciated.

