### PR TITLE
Bug 1068585 - Add 'getvalue' action to tutorial protocol.

### DIFF
--- a/public/scripts/tutorials.js
+++ b/public/scripts/tutorials.js
@@ -217,7 +217,15 @@ define(["jquery", "/external/make-api.js", "/external/requestAnimationFrameShim.
             }
 
             if (!!window.postMessage) {
-              smartlines(data, event.source);
+              if (data.action == "getvalue") {
+                event.source.postMessage(JSON.stringify({
+                  type: "tutorial",
+                  action: "value",
+                  value: editor.panes.codeMirror.getValue()
+                }), "*");
+              } else {
+                smartlines(data, event.source);
+              }
             }
           });
         }


### PR DESCRIPTION
This is a potential solution to [bug 1068585](https://bugzilla.mozilla.org/show_bug.cgi?id=1068585). If the tutorial pane sends its parent window a JSON-stringified message with the following content:

```json
{
  "type": "tutorial",
  "action": "getvalue"
}
```

The parent window will immediately respond with the following JSON-stringified message:

```json
{
  "type": "tutorial",
  "action": "value",
  "value": "contents of codeMirror.getValue() will go here"
}
```
