### PR TITLE
Fix #503 - Automatically pass query string params down to the editor iframe

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -62,6 +62,10 @@ module.exports = function(utils, env, nunjucksEnv, appName) {
         }));
       }
 
+      // We forward query string params down to the editor iframe so that
+      // it's easy to do things like enableExtensions/disableExtensions
+      var queryString = url.parse(req.url).search || '';
+
       res.render('index.html', {
         appname: appName,
         appURL: appURL,
@@ -80,7 +84,7 @@ module.exports = function(utils, env, nunjucksEnv, appName) {
         userbar: userbarEndpoint,
         webmaker: webmaker,
         makedetails: makedetails,
-        editorURL: editorURL,
+        editorURL: editorURL + queryString,
         editorHOST: editorHOST
       });
     },

--- a/routes/index.js
+++ b/routes/index.js
@@ -84,7 +84,7 @@ module.exports = function(utils, env, nunjucksEnv, appName) {
         userbar: userbarEndpoint,
         webmaker: webmaker,
         makedetails: makedetails,
-        editorURL: editorURL + queryString,
+        editorURL: editorURL + '/index.html' + queryString,
         editorHOST: editorHOST
       });
     },


### PR DESCRIPTION
To test this, you can do:
* http://localhost:3500 (i.e., no query string).  Should load Bramble normally
* http://localhost:3500?enableExtensions=CodeFolding the CodeFolding extension should be on (little triangles next to collapsable bits of the html file)
* http://locahost:3500?ui=1 Should show the full Brackets UI