### PR TITLE
[WIP] Integrate ID into thimble

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,12 +1,14 @@
 {
   "name": "thimble.webmaker.org",
   "dependencies": {
+    "cookies-js": "~1.2.1",
     "makerstrap": "~0.2.7",
+    "node-uuid": "~1.4.3",
+    "url-template": "~2.0.4",
     "webmaker-analytics": "0.1.0",
     "webmaker-i18n": "https://github.com/mozilla/node-webmaker-i18n/archive/v0.3.8.tar.gz",
     "webmaker-language-picker": "0.0.26",
-    "webmaker-login-ux": "1.3.5",
-    "url-template": "~2.0.4"
+    "webmaker-login-ux": "1.3.5"
   },
   "resolutions": {
     "selectize": "0.10.1"

--- a/env.dist
+++ b/env.dist
@@ -124,5 +124,10 @@ export THIMBLE_MAIN_BRANCH=""
 ## Which remote is considered upstream?
 export THIMBLE_MAIN_REMOTE=""
 
+##
+# id.wm.o config
+#
 
-
+export OAUTH_CLIENT_ID="test"
+export OAUTH_CLIENT_SECRET="test"
+export OAUTH_AUTHORIZATION_URL="http://localhost:1234"

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -1,0 +1,5 @@
+var habitat = require('habitat');
+habitat.load(require('path').resolve(__dirname, '../.env'));
+var env = new habitat();
+
+module.exports = env;

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -1,4 +1,6 @@
-module.exports = function(env) {
+var env = require('./environment');
+
+module.exports = function() {
   var options = {
       host: env.get('STATSD_HOST'),
       port: env.get('STATSD_PORT'),

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -1,10 +1,14 @@
-module.exports = function middlewareConstructor(env) {
+var env = require('./environment');
 
-  var metrics = require('./metrics')(env),
+module.exports = function middlewareConstructor() {
+  var metrics = require('./metrics')(),
       utils = require("./utils"),
       hood = require("hood"),
       emulate_s3 = env.get('S3_EMULATION') || !env.get('S3_KEY'),
-      knox = emulate_s3 ? require("noxmox").mox : require("knox");
+      knox = emulate_s3 ? require("noxmox").mox : require("knox"),
+      Cryptr = require("cryptr");
+
+  var cryptr = new Cryptr(env.get("SESSION_SECRET"));
 
   return {
     /**
@@ -512,6 +516,22 @@ module.exports = function middlewareConstructor(env) {
           res.json({"status": 200});
         });
       };
+    },
+
+    /**
+     * If there's an oauth token, decrypt it and set the
+     * local user object.
+     */
+    setUserIfTokenExists: function(req, res, next) {
+      if (!req.session || !req.session.token) {
+        return next();
+      }
+
+      // Decrypt oauth token
+      req.user = req.session.user;
+      req.user.token = cryptr.decrypt(req.session.token);
+
+      next();
     }
   };
 };

--- a/lib/parameters.js
+++ b/lib/parameters.js
@@ -33,7 +33,9 @@ var whitelisted_projects = [
   "tutorial"
 ];
 
-module.exports = function(env) {
+var env = require('./environment');
+
+module.exports = function() {
 
   var makeapi = require("./makeapi")(env.get("make"));
 

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -2,8 +2,9 @@
  * Contact a webmaker-fork of atmos/camo for resource proxying of http
  * resources on our https websites (webmaker.org and makes.org).
  */
-module.exports = function(env) {
+var env = require('./environment');
 
+module.exports = function() {
   var crypto = require("crypto");
   var key = env.get("PROXY_KEY");
   var proxyHost = env.get("PROXY_HOSTNAME");

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "async": "0.2.7",
     "bower": "1.3.8",
+    "cryptr": "^1.0.0",
     "express": "3.4.5",
     "habitat": "0.4.1",
     "helmet": "0.1.2",

--- a/public/friendlycode/js/require-config.js
+++ b/public/friendlycode/js/require-config.js
@@ -51,7 +51,9 @@ var require = {
     "list": "/bower/listjs/dist/list.min",
     "fuzzySearch": "/bower/list.fuzzysearch.js/dist/list.fuzzysearch.min",
     "analytics": "/bower/webmaker-analytics/analytics",
-    "url-template": "/bower/url-template/lib/url-template"
+    "url-template": "/bower/url-template/lib/url-template",
+    "uuid": "/bower/node-uuid/uuid",
+    "cookies": "/bower/cookies-js/dist/cookies"
   },
   config: {
     template: {

--- a/views/index.html
+++ b/views/index.html
@@ -2,13 +2,15 @@
 {% block body %}
     <script src="{{ personaHost }}/include.js"></script>
     {% include 'userbar.html' %}
-    <script src="/bower/webmaker-login-ux/dist/min/webmakerLogin.min.js"></script>
     {% include 'tutorialbar.html' %}
     {% include 'friendlycode.html' %}
     {% block ssooverride %}
       <script id="ssooverride" src="/scripts/ssooverride.js"
-              data-csrf="{{ csrf }}"
-              data-login-hostname="{{ LOGIN_URL }}"
+              data-login-authHostname="{{ OAUTH_AUTHORIZATION_URL }}"
+              data-login-thimbleHostname="{{ appURL }}"
+              data-oauth-clientid="{{ OAUTH_CLIENT_ID }}"
+              data-oauth-username="{{ username }}"
+              data-oauth-avatar="{{ avatar }}"
               data-login-to-save="{{ gettext('Login to save') }}"
               async>
       </script>

--- a/views/userbar.html
+++ b/views/userbar.html
@@ -38,22 +38,6 @@
                 </a>
                 <ul class="dropdown-menu">
                   <li>
-                    <a href="{{ webmaker }}/{{ localeInfo.lang }}/me">
-                      <span class="fa fa-fw fa-th-large"></span> My makes
-                    </a>
-                  </li>
-                  <li>
-                    <a data-profile data-href-template="{{ webmaker }}/{{ localeInfo.lang }}/user/{username}">
-                      <span class="fa fa-fw fa-user"></span> My profile
-                    </a>
-                  </li>
-                  <li>
-                    <a href="{{ LOGIN_URL }}/{{ localeInfo.lang }}/account">
-                      <span class="fa fa-fw fa-cog"></span> My settings
-                    </a>
-                  </li>
-                  <li class="divider"></li>
-                  <li>
                     <a class="logout-button">
                       <span class="fa fa-fw fa-sign-out"></span> Sign out
                     </a>


### PR DESCRIPTION
This is a full implementation of Thimble using the [id.webmaker.org](https://github.com/mozilla/id.webmaker.org) oauth2 server for authentication. Very little UX was changed since a refresh is in the works.

**Known issues:**

1.  Logging in will lose all work in the editor. 
2.  Toolbar links to "my profile", "my settings" and "my makes" won't work since the rest of wm.o isn't configured to use `id`. 
3.  Thimble must completely load before signing in is possible.

**Test instructions:**

1. Clone, install, configure and run [id.webmaker.org](https://github.com/mozilla/id.webmaker.org). You'll need to install and run postgres to make this work, and you'll need to create and populate the `webmaker_oauth_test` database. Copy [this sql in this gist](http://pastebin.com/mqSS9bnu) over the `test-data.sql` file before running `test-data.js`. Also, unlike the other parts of webmaker, ID doesn't automatically manage the environment variables so a little more work is needed. (I can help walk people through this part)
2. Configure and run thimble with the [new .env vars](https://github.com/mozilla/thimble.webmaker.org/pull/518/files#diff-45473cb0daa25d5231f105558b5b7226R131)
3. Run the wm.o login server