### PR TITLE
Only 100% translated langs, override lang picker width

### DIFF
--- a/env.dist
+++ b/env.dist
@@ -103,7 +103,7 @@ export STATSD_PREFIX=
 export FORCE_SSL=false
 
 # i18n Language Support
-export SUPPORTED_LANGS='[ "*" ]'
+export SUPPORTED_LANGS="[ "th-TH", "es-AR", "te", "pt-BR", "de", "tr-TR", "uz", "el", "km", "en-US", "es", "ru", "es-CL", "ro", "en-CA", "bn-BD", "uk", "da-DK", "ja", "ca", "vi-VN", "fi", "pt", "hi-IN", "en-GB", "zh-TW", "he", "zh-CN", "mr", "my", "is", "it", "ar", "es-419", "id", "bn-IN", "nl", "or-IN", "ne", "fr", "ko-KR", "fa", "es-MX", "sr", "sq", "sv", "sk", "sl", "pl-PL" ]"
 
 export ENABLE_GELF_LOGS=false
 

--- a/public/stylesheets/userbar-overrides.less
+++ b/public/stylesheets/userbar-overrides.less
@@ -61,6 +61,10 @@
     }
 }
 
+.language-picker-box { 
+    width: auto;
+}
+
 .icon-globe {
     display: inline-block;
     font: normal normal normal 14px/1 FontAwesome; // shortening font declaration


### PR DESCRIPTION
Changed dist model for .env to provide only langs with 100% translation, override language box width to auto.