### PR TITLE
Ignore css files generated during node app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ bower_components
 locale/
 !locale/en_US/*
 !locale/localeinfo.json
+public/friendlycode/css/editor.css
+public/stylesheets/userbar.css


### PR DESCRIPTION
Updated to ignore:
public/friendlycode/css/editor.css
public/stylesheets/userbar.css