### PR TITLE
Stay Calm template for user testing, minor fix to node error handling

### DIFF
--- a/lib/errorhandling.js
+++ b/lib/errorhandling.js
@@ -14,7 +14,8 @@ function renderError( err, res ) {
   });
 }
 
-module.exports.errorHandler = function(err, req, res) {
+module.exports.errorHandler = function(err, req, res, next) {
+  //jshint unused:vars
   if (typeof err === "string") {
     console.error("You're passing a string into next(). Go fix this: %s", err);
   }

--- a/public/friendlycode/js/fc/load-project-files.js
+++ b/public/friendlycode/js/fc/load-project-files.js
@@ -1,4 +1,5 @@
-define(["jquery", "constants"], function($, Constants) {
+define(["jquery", "constants", "text!fc/stay-calm/index.html", "text!fc/stay-calm/style.css"],
+ function($, Constants, defaultHTML, defaultCSS) {
   var Path = Bramble.Filer.Path;
   var FilerBuffer = Bramble.Filer.Buffer;
 
@@ -192,10 +193,15 @@ define(["jquery", "constants"], function($, Constants) {
     };
   }
 
+  // XXX: For user testing, we're going to start with the "Stay Calm" poster project
   function generateDefaultFiles(defaultTemplate, projectPath) {
     return [{
-      path: Path.join(projectPath, Constants.DEFAULT_FILE_NAME),
-      buffer: convertToArrayBuffer(defaultTemplate)
+      path: Path.join(projectPath, "index.html"),
+      buffer: convertToArrayBuffer(defaultHTML)
+    },
+    {
+      path: Path.join(projectPath, "style.css"),
+      buffer: convertToArrayBuffer(defaultCSS)
     }];
   }
 

--- a/public/friendlycode/js/fc/stay-calm/index.html
+++ b/public/friendlycode/js/fc/stay-calm/index.html
@@ -1,0 +1,25 @@
+<html>
+  <head>
+    <!-- This is the title of the page - what's written will appear at the top of the browser window -->
+    <title>Keep Calm ad Carry On</title>
+
+    <!-- This links to the stylesheet for this page -->
+    <link rel="stylesheet" type="text/css" href="style.css">
+  </head>
+
+  <body>
+    <div class="wrapper">
+
+      <!-- This is the crown image used at the top of the poster -->
+      <img src="http://stuff.webmaker.org.s3.amazonaws.com/crown.png" width="125">
+
+      <!-- This is the text of the poster -->
+      <h1>
+        Keep<br> Calm
+        <span>and</span>
+        Carry<br> On
+      </h1>
+
+    </div>
+  </body>
+</html>

--- a/public/friendlycode/js/fc/stay-calm/style.css
+++ b/public/friendlycode/js/fc/stay-calm/style.css
@@ -1,0 +1,28 @@
+body {
+  background-color: darkred;
+  color: white;
+  font-family: "Gill Sans", "Gill Sans MT", Calibri, sans-serif;
+  text-align: center;
+  padding: 0;
+}
+
+.wrapper {
+  margin: 10px auto;
+  max-width: 300px;
+  padding: 30px;
+  border: 4px double white;
+}
+
+h1 {
+  font-size: 60px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  font-weight: normal;
+  margin-top: 30px;
+  margin-bottom: 0;
+}
+
+h1 span {
+  display: block;
+  font-size: 50%;
+}


### PR DESCRIPTION
I've also slipped in a minor fix to the error handling middleware we use, which was wrong before.

This temporarily overrides how we do the default project content so @flukeout can do user testing, see https://github.com/mozilla/thimble.webmaker.org/issues/558#issuecomment-117259560