### PR TITLE
Added underlay for options menu, close menu on outside click

### DIFF
--- a/public/friendlycode/css/editor.less
+++ b/public/friendlycode/css/editor.less
@@ -201,7 +201,7 @@
 /* ------ EDITOR OPTIONS MENU ------ */
 #editor-pane-nav-options-menu {
   position: absolute;
-  z-index: 6;
+  z-index: 151;
   background-color: white;
   -webkit-box-shadow: 0 3px 9px rgba(0,0,0,0.24);
   -moz-box-shadow: 0 3px 9px rgba(0,0,0,0.24);
@@ -232,6 +232,16 @@
   z-index: 1;
   top: -15px;
   left: 83px;
+}
+#editor-pane-nav-options-underlay {
+  width: 100%;
+  min-height: 100%;
+  position: fixed;
+  top: 0;
+  left: 0;
+  background-color: rgba(0, 0, 0, 0.4);
+  z-index: 150;
+  overflow: hidden;
 }
 
 /* Font increase/decrease */

--- a/public/friendlycode/js/fc/bramble-ui-bridge.js
+++ b/public/friendlycode/js/fc/bramble-ui-bridge.js
@@ -89,16 +89,12 @@ define(["jquery"], function($) {
       var leftOffset = $("#editor-pane-nav-options").offset().left - 86;
       $("#editor-pane-nav-options-menu").css("left", leftOffset);
       $("#editor-pane-nav-options-menu").fadeToggle();
+      $("#editor-pane-nav-options-underlay").toggle();
     });
 
-    $(document).on('click', function(event) {
-      if (!$(event.target).closest("#editor-pane-nav-options-menu").length && !$(event.target).closest("#editor-pane-nav-options").length) {
-        $("#editor-pane-nav-options-menu").hide();
-      }
-    });
-    $("#webmaker-bramble").click(function() {
-      $("#editor-pane-nav-options-menu").hide();
-      console.log("Within iframe");
+    $("#editor-pane-nav-options-underlay").click(function() {
+      $("#editor-pane-nav-options-menu").fadeOut();
+      $("#editor-pane-nav-options-underlay").hide();
     });
 
     // Font size

--- a/views/friendlycode/templates/nav-options.html
+++ b/views/friendlycode/templates/nav-options.html
@@ -38,6 +38,7 @@
         </div>
 
           <img id="editor-pane-nav-options" src="/img/icon/gear-white.svg" width="25px" height="25px">
+          <div id="editor-pane-nav-options-underlay" class="hide"></div>
           <div id="editor-pane-nav-options-menu" class="hide">
             <ul>
               <li><span>Text size</span>


### PR DESCRIPTION
Fixed closing the menu when clicking outside, as per feedback by users on #649 
cc @humphd or @flukeout for r.