### PR TITLE
Fix #711 - Enter and Esc keys should work on project rename field

### DIFF
--- a/public/scripts/editor/js/fc/bramble-keyhandler.js
+++ b/public/scripts/editor/js/fc/bramble-keyhandler.js
@@ -1,8 +1,8 @@
 define(["jquery"], function($) {
 
   // Run the given function `fn` when the key with `keyCode` is pressed down
-  function KeyHandler(keyCode, fn) {
-    this._handler = function(e) {
+  function KeyHandler(keyCode, elem, fn) {
+    function handler(e) {
       if(e.which !== keyCode) {
         return;
       }
@@ -10,22 +10,35 @@ define(["jquery"], function($) {
       e.stopPropagation();
       e.preventDefault();
       fn();
-    };
+    }
 
-    $(document).on("keydown", this._handler);
+    if(typeof elem === "function") {
+      fn = elem;
+      elem = document;
+    }
+
+    $(elem).on("keydown", handler);
+
+    this.stop = function() {
+      $(elem).off("keydown", handler);
+    };
   }
-  KeyHandler.prototype.stop = function() {
-    $(document).off("keydown", this._handler);
-  };
 
   // Helper for ESC key handling
-  function EscKeyHandler(fn) {
-    KeyHandler.call(this, 27, fn);
+  function EscKeyHandler(elem, fn) {
+    KeyHandler.call(this, 27, elem, fn);
   }
   EscKeyHandler.prototype = KeyHandler.prototype;
   EscKeyHandler.prototype.constructor = EscKeyHandler;
-
   KeyHandler.ESC = EscKeyHandler;
+
+  // Helper for Enter key handling
+  function EnterKeyHandler(elem, fn) {
+    KeyHandler.call(this, 13, elem, fn);
+  }
+  EnterKeyHandler.prototype = KeyHandler.prototype;
+  EnterKeyHandler.prototype.constructor = EnterKeyHandler;
+  KeyHandler.Enter = EnterKeyHandler;
 
   return KeyHandler;
 });


### PR DESCRIPTION
The event state becomes a bit trickier when you can click or press enter, so I have to do more work to manually add/remove event listeners, which makes the `project-rename.js` code a bit more complicated.

One thing I notice about this UX for another bug: there is no non-keyboard way to cancel a rename once you start.  I wonder if we should have a way to do "Save" or "Cancel" (checkmark and an x?).  cc @flukeout