### PR TITLE
Initial UI for Thimble to use Bramble Tutorial feature, part of #573

### DIFF
--- a/public/scripts/editor/js/fc/bramble-ui-bridge.js
+++ b/public/scripts/editor/js/fc/bramble-ui-bridge.js
@@ -165,6 +165,56 @@ define(function(require) {
       bramble.refreshPreview();
     });
 
+
+    // Preview vs. Tutorial preview mode. First check to see if there
+    // is a tutorial.html file, and only show the TUTORIAL link if there is.
+    if(bramble.getTutorialExists()) {
+      $("#tutorial-title").removeClass("hide");
+    }
+    // And listen for changes to the project, in terms of one being added/removed
+    bramble.on("tutorialAdded", function() {
+      $("#tutorial-title").removeClass("hide");
+    });
+    bramble.on("tutorialRemoved", function() {
+      $("#tutorial-title").addClass("hide");
+    });
+
+    function setNormalPreview() {
+      $("#tutorial-title").removeClass("preview-title-highlighted");
+      $("#preview-title").addClass("preview-title-highlighted");
+    }
+
+    function setTutorialPreview() {
+      $("#preview-title").removeClass("preview-title-highlighted");
+      $("#tutorial-title").addClass("preview-title-highlighted");
+    }
+
+    // User change to tutorial vs. regular preview mode
+    $("#preview-title").click(function() {
+      if(!bramble.getTutorialVisible()) {
+        return;
+      }
+
+      bramble.hideTutorial(setNormalPreview);
+    });
+    $("#tutorial-title").click(function() {
+      if(bramble.getTutorialVisible()) {
+        return;
+      }
+
+      bramble.showTutorial(setTutorialPreview);
+    });
+
+    // Programmatic change to tutorial vs. regular preview mode from Bramble
+    bramble.on("tutorialVisibilityChange", function(data) {
+      if(data.visibility) {
+        setTutorialPreview();
+      } else {
+        setNormalPreview();
+      }
+    });
+
+
     // Preview Mode Toggle
     $("#preview-pane-nav-desktop").click(function() {
       activatePreviewMode("desktop");

--- a/public/stylesheets/editor.less
+++ b/public/stylesheets/editor.less
@@ -321,6 +321,12 @@
   color: #A9A9A9;
   font-weight: bold;
   font-size: 1em;
+  cursor: pointer;
+}
+
+.preview-title-highlighted {
+  color: #767676;
+  border-bottom: 3px solid #767676;
 }
 
 #preview-pane-nav-refresh {

--- a/views/nav-options.html
+++ b/views/nav-options.html
@@ -72,10 +72,11 @@
   <!-- RIGHT SIDE -->
   <div class="preview-pane-nav">
     <div class="nav-container">
-      <span class="preview-pane-nav-title">PREVIEW</span>
+      <span id="preview-title" class="preview-pane-nav-title preview-title-highlighted">PREVIEW</span>
       <div id="preview-pane-nav-refresh">
         <img src="/img/icon/refresh.svg" width="20px" height="20px">
       </div>
+      <span id="tutorial-title" class="preview-pane-nav-title hide">TUTORIAL</span>
       <div class="flex-container pull-right">
         <img id="preview-pane-nav-desktop" class="viewmode-active" src="/img/icon/desktop.svg"  width="30px" height="30px">
         <img id="preview-pane-nav-phone" class="viewmode-inactive" src="/img/icon/phone-portrait.svg" width="30px" height="30px">


### PR DESCRIPTION
This is only a start, but it lets us really get a feel for things.  I still need a visual way to add the tutorial.html, but adding one manually (right-click in file tree, name your file `tutorial.html`) will have the right effect.

I keep track of whether or not there is a tutorial, and show/hide the TUTORIAL button accordingly.  I have to fix one bug in Bramble where deleting an active `tutorial.html` file leaves you in tutorial mode--it doesn't cause problems, but it's not right.  I'll file after this.