### PR TITLE
Fix #699 - Make publish dialog show 'update published...' button even if changes haven't been saved

### DIFF
--- a/public/scripts/editor/js/fc/bramble-ui-bridge.js
+++ b/public/scripts/editor/js/fc/bramble-ui-bridge.js
@@ -256,6 +256,13 @@ define(function(require) {
 
       // Listen for ESC to close
       _escKeyHandler = new KeyHandler.ESC(hidePublishDialog);
+
+      publisher.fsync.saveAndSyncAll(function(err) {
+        if (err) {
+          console.log('[Bramble] Error saving and persisting dirty files:', err);
+          return;
+        }
+      });
     }
 
     if(options.authenticated) {


### PR DESCRIPTION
Testing steps:

1.  Publish a project
2.  Make changes
3.  Before it auto-saves, click "Publish"

It should quickly update to show the "Updated Published" button.