### PR TITLE
Fix #788 - transform paths from symlinked to real project paths

### DIFF
--- a/public/scripts/editor/js/bramble-editor.js
+++ b/public/scripts/editor/js/bramble-editor.js
@@ -4,33 +4,7 @@ define(function(require) {
       ProjectRenameUtility = require("fc/project-rename"),
       ProjectFiles = require("fc/load-project-files"),
       FileSystemSync = require("fc/filesystem-sync"),
-      uuid = require("uuid"),
-      Path = Bramble.Filer.Path;
-
-  // Bramble loads all projects via symlinks stored in entries named /.mnt/<uuid>
-  var MOUNT_DIR = "/.mnt";
-
-  function createMountPoint(config, callback) {
-    var mountPoint = Path.join(MOUNT_DIR, uuid.v4());
-
-    config.shell.mkdirp(MOUNT_DIR, function(err) {
-      if(err && err.code !== "EEXIST") {
-        console.error("[Bramble Error] Failed to create mount directory:", err);
-        callback(err);
-        return;
-      }
-
-      config.fs.symlink(config.root, mountPoint, function(err) {
-        if(err) {
-          console.error("[Bramble Error] Failed to create project symlink:", err);
-          callback(err);
-          return;
-        }
-
-        callback(null, mountPoint);
-      });
-    });
-  }
+      PathUtils = require("fc/path-utils");
 
   return function BrambleEditor(options) {
     var makeDetails = options.makeDetails;
@@ -80,7 +54,7 @@ define(function(require) {
       // Put a level of indirection between the project root and Bramble
       // so that moving or renaming the project files is painless (i.e.,
       // Bramble will only ever know about this symlink).
-      createMountPoint(config, function(err, mountPoint) {
+      PathUtils.createMountPoint(config.root, function(err, mountPoint) {
         if(err) {
           console.error("[Bramble Error] Unable to mount project directory");
           return;

--- a/public/scripts/editor/js/fc/bramble-ui-bridge.js
+++ b/public/scripts/editor/js/fc/bramble-ui-bridge.js
@@ -4,6 +4,7 @@ define(function(require) {
   var KeyHandler = require("fc/bramble-keyhandler");
   var BrambleMenus = require("fc/bramble-menus");
   var Underlay = require("fc/bramble-underlay");
+  var PathUtils = require("fc/path-utils");
 
   var _escKeyHandler;
 
@@ -243,25 +244,57 @@ define(function(require) {
     });
 
     bramble.on("activeEditorChange", function(data) {
-      console.log("thimble side", "activeEditorChange", data);
-      setNavFilename(data.filename);
+      PathUtils.transformPath(bramble, data.fullPath, function(err, fullPath) {
+        if(err) {
+          console.error("[Thimble Error] unable to transform path", err);
+          return;
+        }
+
+        console.log("activeEditorChange", fullPath);
+        setNavFilename(data.filename);
+      });
     });
 
     // File Change Events
     bramble.on("fileChange", function(filename) {
-      console.log("thimble side", "fileChange", filename);
-      showFileState();
+      PathUtils.transformPath(bramble, filename, function(err, fullPath) {
+        if(err) {
+          console.error("[Thimble Error] unable to transform path", err);
+          return;
+        }
+
+        console.log("fileChange", fullPath);
+        showFileState();
+      });
     });
 
     bramble.on("fileDelete", function(filename) {
-      console.log("thimble side", "fileDelete", filename);
-      showFileState();
+      PathUtils.transformPath(bramble, filename, function(err, fullPath) {
+        if(err) {
+          console.error("[Thimble Error] unable to transform path", err);
+          return;
+        }
+
+        console.log("fileDelete", fullPath);
+        showFileState();
+      });
     });
 
     bramble.on("fileRename", function(oldFilename, newFilename) {
-      console.log("thimble side", "fileRename", oldFilename, newFilename);
-      setNavFilename(newFilename);
-      showFileState();
+      PathUtils.transformPaths(bramble, [oldFilename, newFilename], {projectRelative: true},
+        function(err, fullPaths) {
+          if(err) {
+            console.error("[Thimble Error] unable to transform paths", err);
+            return;
+          }
+
+          var oldFilename = fullPaths[0];
+          var newFilename = fullPaths[1];
+
+          console.log("fileRename", oldFilename, newFilename);
+          setNavFilename(newFilename);
+          showFileState();
+        });
     });
   }
 

--- a/public/scripts/editor/js/fc/path-utils.js
+++ b/public/scripts/editor/js/fc/path-utils.js
@@ -1,0 +1,83 @@
+define(function() {
+  var Path = Bramble.Filer.Path;
+  var uuid = require("uuid");
+  var fs = Bramble.getFileSystem();
+  var sh = fs.Shell();
+
+  // Bramble loads all projects via symlinks stored in entries named /.mnt/<uuid>
+  var MOUNT_DIR = "/.mnt";
+
+  function createMountPoint(root, callback) {
+    var mountPoint = Path.join(MOUNT_DIR, uuid.v4());
+
+    sh.mkdirp(MOUNT_DIR, function(err) {
+      if(err && err.code !== "EEXIST") {
+        console.error("[Bramble Error] Failed to create mount directory:", err);
+        callback(err);
+        return;
+      }
+
+      fs.symlink(root, mountPoint, function(err) {
+        if(err) {
+          console.error("[Bramble Error] Failed to create project symlink:", err);
+          callback(err);
+          return;
+        }
+
+        callback(null, mountPoint);
+      });
+    });
+  }
+
+  // Transform paths from symlinked (/.mnt/...) to real paths
+  function transformPaths(bramble, paths, options, callback) {
+    if(typeof options === "function") {
+      callback = options;
+      options = null;
+    }
+    options = options || {};
+
+    var brambleRoot = bramble.getRootDir();
+
+    // If all the user wants is a relative path into the project root
+    // just strip the brambleRoot off all the paths and return.
+    if(options.projectRelative) {
+      return callback(null, paths.map(function(path) {
+        return path.slice(brambleRoot.length);
+      }));
+    }
+
+    // Otherwise, read the symlink's realpath and use that as the prefix.
+    fs.readlink(brambleRoot, function(err, realpath) {
+      if(err) {
+        return callback(err);
+      }
+
+      callback(null, paths.map(function(path) {
+        return Path.join(realpath, Path.relative(brambleRoot, path));
+      }));
+    });
+  }
+
+  // Single path version for ease of use.
+  function transformPath(bramble, path, options, callback) {
+    if(typeof options === "function") {
+      callback = options;
+      options = null;
+    }
+    options = options || {};
+
+    transformPaths(bramble, [path], options, function(err, paths) {
+      if(err) {
+        return callback(err);
+      }
+      callback(null, paths[0]);
+    });
+  }
+
+  return {
+    transformPaths: transformPaths,
+    transformPath: transformPath,
+    createMountPoint: createMountPoint
+  };
+});


### PR DESCRIPTION
This takes a path like `/.mnt/1234asd;flkj234j/index.html` and transforms it into `/7/projects/12/index.html` so that we can send it to the server.  It depends on https://github.com/humphd/brackets/pull/404, which I'm about to land, but FYI.  Also, I can't test this locally, so I need to test it with someone on appear.

This should also fix the `Strange filename listed at the top of the Editor window` case in #754.