### PR TITLE
Kill off CSP violations and reduce CSP warning spam on console

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -71,6 +71,7 @@ module.exports = function middlewareConstructor() {
             "https://ajax.googleapis.com",
             "https://mozorg.cdn.mozilla.net",
             "https://www.google-analytics.com",
+            options.brambleHost,
             options.personaHost
           ],
           'style-src': [

--- a/public/stylesheets/userbar.less
+++ b/public/stylesheets/userbar.less
@@ -1,5 +1,9 @@
 @import url(https://fonts.googleapis.com/css?family=Open+Sans:300,600);
 
+body {
+  margin: 0;
+}
+
 /* Transition time for hover effects */
 @transitionTime: 0.5s;
 

--- a/views/layout.html
+++ b/views/layout.html
@@ -25,7 +25,7 @@
     </script>
     {% endif %}
   </head>
-  <body style="margin: 0" data-make-url="{{ makeUrl }}" data-make-endpoint="{{ MAKE_ENDPOINT }}">
+  <body data-make-url="{{ makeUrl }}" data-make-endpoint="{{ MAKE_ENDPOINT }}">
     {% block body %}{% endblock %}
   </body>
 </html>

--- a/views/nav-options.html
+++ b/views/nav-options.html
@@ -1,7 +1,7 @@
 <div class="editor-nav">
 
   <!-- FILE TREE -->
-  <div class="filetree-pane-nav" style="display:none;">
+  <div class="filetree-pane-nav" class="hide">
     <div class="nav-container">
       <div class="filetree-pane-nav-title">
         FILES

--- a/views/publish.html
+++ b/views/publish.html
@@ -22,7 +22,7 @@
     <div id="publish-button-unpublish">
       <svg height="16" width="16" id="unpublish-icon">
         <circle cx="8" cy="8" r="8" fill="white" />
-        <line x1="11" y1="8" x2="5" y2="8" style="stroke:#B0B0B0;stroke-width:1" />
+        <line x1="11" y1="8" x2="5" y2="8" stroke="#B0B0B0" strokeWeight="1" />
       </svg>
       <span>Unpublish</span>
     </div>


### PR DESCRIPTION
This gets rid of all the annoying CSP warnings.  All that's left are warnings about us being in report-only mode, which is fine.