### PR TITLE
Fix #924 - fix typo on filetree class markup to hide on startup

### DIFF
--- a/views/nav-options.html
+++ b/views/nav-options.html
@@ -1,7 +1,7 @@
 <div class="editor-nav">
 
   <!-- FILE TREE -->
-  <div class="filetree-pane-nav" class="hide">
+  <div class="filetree-pane-nav hide">
     <div class="nav-container">
       <div class="filetree-pane-nav-title">
         FILES


### PR DESCRIPTION
This is my fault, I made a typo when I removed the inline style.  this fixes things on startup so it doesn't show the filetree.