### PR TITLE
Fix #541 - create default empty project

### DIFF
--- a/default/empty-project/index.html
+++ b/default/empty-project/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Made with Thimble</title>
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
 

--- a/default/empty-project/style.css
+++ b/default/empty-project/style.css
@@ -1,0 +1,3 @@
+body {
+  font-family: "Open Sans", sans-serif;
+}

--- a/env.dist
+++ b/env.dist
@@ -132,7 +132,5 @@ export OAUTH_CLIENT_ID="test"
 export OAUTH_CLIENT_SECRET="test"
 export OAUTH_AUTHORIZATION_URL="http://localhost:1234"
 
-# Default content title, which should match a folder inside the repo's
-# /defaults folder
-export DEFAULT_PROJECT_TITLE="stay-calm"
-
+# Default content title, which should match a folder inside the repo's /default folder
+export DEFAULT_PROJECT_TITLE="empty-project"


### PR DESCRIPTION
![screenshot 2015-08-26 17 02 46](https://cloud.githubusercontent.com/assets/427398/9506183/805063f2-4c14-11e5-9425-c71bf5d0648a.png)

I modified what you had in that bug slightly so that it forces HTML5 rendering vs Quirks Mode (doctype) and will render properly in mobile.

@sedge NOTE: we'll need an env update when this lands.