### PR TITLE
Fix #932 - stop popup menu from throwing on resize, missing click events

### DIFF
--- a/public/editor/scripts/editor/js/fc/bramble-popupmenu.js
+++ b/public/editor/scripts/editor/js/fc/bramble-popupmenu.js
@@ -9,6 +9,28 @@ define(function(require) {
     self._button$ = $(button);
     self._menu$ = $(menu);
 
+    self.close = function() {
+      if(!self.showing) {
+        return;
+      }
+
+      $(window).off("resize", self.close);
+
+      self._menu$.hide();
+
+      if(self._underlay) {
+        self._underlay.remove();
+        self._underlay = null;
+      }
+
+      if(self._escKeyHandler) {
+        self._escKeyHandler.stop();
+        self._escKeyHandler = null;
+      }
+
+      delete self.showing;
+    };
+
     // Toggle the menu on/off when the button is clicked.
     self._button$.on("click", function() {
       if(!self.showing) {
@@ -22,31 +44,19 @@ define(function(require) {
     return new PopupMenu(button, menu);
   };
   PopupMenu.prototype.show = function() {
+    var self = this;
+
     // Determine where to horizontally place menu based on button's icon location
+    var menuWidth = self._menu$.width();
+    var leftOffset = self._button$.offset().left - menuWidth/2 + 11;
+    self._menu$.css("left", leftOffset).show();
 
-    var menuWidth = this._menu$.width();
-    var leftOffset = this._button$.offset().left - menuWidth/2 + 11;
-    this._menu$.css("left", leftOffset).show();
-
-    this._underlay = new Underlay(this._menu$, this.close.bind(this));
-    this._escKeyHandler = new KeyHandler.ESC(this.close.bind(this));
+    self._underlay = new Underlay(self._menu$, self.close);
+    self._escKeyHandler = new KeyHandler.ESC(self.close);
     // Close on resize
-    $(window).on("resize", this.close.bind(this));
+    $(window).on("resize", self.close);
 
-    this.showing = true;
-  };
-  PopupMenu.prototype.close = function() {
-    this._menu$.hide();
-
-    this._underlay.remove();
-    this._underlay = null;
-
-    this._escKeyHandler.stop();
-    this._escKeyHandler = null;
-
-    $(window).off("resize", this.close.bind(this));
-
-    delete this.showing;
+    self.showing = true;
   };
 
   return PopupMenu;


### PR DESCRIPTION
This fixes two things:
* properly deals with unbinding the resize event so it doesn't fire forever after closing the popup
* deals with click events on the popup menu button that were being missed (saw this in user testing video).