### PR TITLE
Fix #861 - try to autorecover a corrupt filesystem

### DIFF
--- a/public/editor/scripts/editor/js/bramble-editor.js
+++ b/public/editor/scripts/editor/js/bramble-editor.js
@@ -27,7 +27,8 @@ define(function(require) {
 
       // Start loading the Bramble editor resources
       Bramble.load("#webmaker-bramble",{
-        url: options.editorUrl
+        url: options.editorUrl,
+        autoRecoverFileSystem: true
       });
 
       // Start loading the project files


### PR DESCRIPTION
This depends on https://github.com/humphd/brackets/pull/426, and will silently try to deal with a failed filesystem.  I'm not doing an UI, but a refresh is the most likely outcome for the user.