### PR TITLE
Don't spit out massive error when preloading editor modules on homepage

### DIFF
--- a/public/homepage/scripts/main.js
+++ b/public/homepage/scripts/main.js
@@ -1,3 +1,11 @@
+// Because we pre-load require scripts needed by the editor, we need to
+// eat error messages related to fetching but not using those modules.
+requirejs.onError = function(err) {
+  if(err.requireType !== "mismatch") {
+    throw err;
+  }
+};
+
 require.config({
   baseUrl: "/homepage/scripts",
   paths: {


### PR DESCRIPTION
This overrides the default error handling in require and keeps it from throwing when we preload those Bramble modules, see http://requirejs.org/docs/api.html#errors