### PR TITLE
Preload large Bramble assets on homepage in order to cache

### DIFF
--- a/public/homepage/scripts/main.js
+++ b/public/homepage/scripts/main.js
@@ -21,6 +21,20 @@ require.config({
   }
 });
 
+// While the user is reading this page, start to cache Bramble's biggest files
+function preloadBramble($) {
+  var brambleHost = $("meta[name='bramble-host']").attr("content");
+  [
+    brambleHost + "/dist/styles/brackets.min.css",
+    brambleHost + "/dist/bramble.js",
+    brambleHost + "/dist/main.js",
+    brambleHost + "/dist/thirdparty/thirdparty.min.js"
+  ].forEach(function(url) {
+    // Load and cache files as plain text (don't parse) and ignore results.
+    $.ajax({url: url, dataType: "text"});
+  });
+}
+
 // At this point, all the homepage needs is handlers for the login/logout
 // flow. If more needs to be added, the logic should be factored out into
 // separate modules, each of which would be initialized here.
@@ -66,6 +80,8 @@ function init($, uuid, cookies) {
     queryString = queryString === "" ? "?" + cacheBust : queryString + "&" + cacheBust;
     window.location.href = "/projects/new"  + queryString;
   });
+
+  preloadBramble($);
 }
 
 require(['jquery', 'uuid', 'cookies'], init);

--- a/views/homepage/index.html
+++ b/views/homepage/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     {{ newrelic.getBrowserTimingHeader() | safe }}
     <meta http-equiv="X-UA-Compatible" content="IE=Edge">
+    <meta name="bramble-host" content="{{editorHOST}}">
 
     <link rel="stylesheet" href="/resources/stylesheets/userbar.css">
     <link rel="stylesheet" href="/homepage/stylesheets/style.css">


### PR DESCRIPTION
This fixes how I was doing the pre-fetching of Bramble's largest assets.  This is going to need a CORS update to our staging and prod S3 buckets, in order to allow our various Thimble servers to xhr GET some files from the Bramble S3 bucket.  @jbuck, can you help with this, I followed http://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html#how-do-i-enable-cors:

```xml
<CORSConfiguration>
 <CORSRule>
   <AllowedOrigin>https://bramble.mofostaging.net</AllowedOrigin>
   <AllowedMethod>GET</AllowedMethod>
   <AllowedHeader>*</AllowedHeader>
 </CORSRule>
 <CORSRule>
   <AllowedOrigin>https://thimble-beta.webmaker.org</AllowedOrigin>
   <AllowedMethod>GET</AllowedMethod>
   <AllowedHeader>*</AllowedHeader>
 </CORSRule>
 <CORSRule>
   <AllowedOrigin>https://thimble.mozilla.org</AllowedOrigin>
   <AllowedMethod>GET</AllowedMethod>
   <AllowedHeader>*</AllowedHeader>
 </CORSRule>
</CORSConfiguration>
```