### PR TITLE
Warn users with browsers that aren't known to work with Thimble

### DIFF
--- a/app.js
+++ b/app.js
@@ -31,7 +31,8 @@ var favicon = require('serve-favicon'),
     logger = require('morgan'),
     compress = require('compression'),
     bodyParser = require('body-parser'),
-    csrf = require('csurf');
+    csrf = require('csurf'),
+    useragent = require('express-useragent');
 
 var appName = "thimble",
     app = express(),
@@ -143,6 +144,9 @@ app.use(lessMiddleWare('public', {
   yuicompress: optimize,
   optimization: optimize ? 0 : 2
 }));
+
+// Temporary fix to warn users in some browsers of UI issues
+app.use(useragent.express());
 
 routes.init(app, middleware);
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "cryptr": "^1.0.0",
     "csurf": "^1.8.3",
     "express": "^4.13.0",
+    "express-useragent": "^0.1.9",
     "form-data": "^0.2.0",
     "grunt": "~0.4.1",
     "grunt-browserify": "^3.8.0",

--- a/public/editor/scripts/editor/js/bramble-editor.js
+++ b/public/editor/scripts/editor/js/bramble-editor.js
@@ -49,11 +49,6 @@ define(function(require) {
         window.bramble = bramble;
         BrambleUIBridge.init(bramble, { sync: fsync });
       });
-
-      Bramble.once("error", function(err) {
-        console.error("[Bramble Error]", err);
-        $("#spinner-container").addClass("loading-error");
-      });
     }
   };
 });

--- a/public/editor/scripts/main.js
+++ b/public/editor/scripts/main.js
@@ -51,4 +51,26 @@ function init(BrambleEditor, Project, SSOOverride, ProjectRenameUtility) {
   });
 }
 
-require(["bramble-editor", "project", "sso-override", "fc/project-rename"], init);
+require(["jquery"], function($) {
+  // Deal with browsers that can't load some parts of Bramble
+  $(".let-me-in").on("click", function(e) {
+    $("#browser-support-warning").fadeOut();
+    return false;
+  });
+
+  function onError(err) {
+    console.error("[Bramble Error]", err);
+    $("#spinner-container").addClass("loading-error");
+  }
+
+  // If Bramble fails to load (some browser loading issues cause it to fail),
+  // error out now, since we won't get to Bramble.on('error', ...)
+  if(!window.Bramble) {
+    onError(new Error("Unable to load Bramble editor in this browser"));
+    return;
+  }
+
+  Bramble.once("error", onError);
+
+  require(["bramble-editor", "project", "sso-override", "fc/project-rename"], init);
+});

--- a/public/editor/stylesheets/editor.less
+++ b/public/editor/stylesheets/editor.less
@@ -634,3 +634,67 @@
 .hide {
   display: none;
 }
+
+#browser-support-warning {
+    position: fixed;
+    background: rgba(11,67,38,.9);
+    top:0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 9999;
+
+    .message-box {
+        border-radius: 2px;
+        position: absolute;
+        width: 500px;
+        background: white;
+        color: black;
+        padding: 20px;
+        box-sizing: border-box;
+        left: ~"calc(50% - 250px)";
+        top: ~"calc(50% - 150px)";
+
+        h1 {
+            margin: 0 0 15px 0;
+            padding: 0;
+            font-size: 22px;
+        }
+
+        p {
+            margin: 0 0 10px 0;
+        }
+
+        a {
+            color: #28975a;
+            text-decoration: none;
+            font-weight: bold;
+
+            &:hover {
+                text-decoration: underline;
+            }
+        }
+
+        .let-me-in {
+            display: inline-block;
+            padding: 12px 15px 11px 15px;
+            background: @buttonGreen;
+            color: white;
+            font-weight: normal;
+            border-radius: 2px;
+            margin-top: 15px;
+            text-decoration: none;
+            border-bottom: solid 2px rgba(0,0,0,.1);
+            cursor: pointer;
+
+            &:hover {
+                background: @buttonGreenHover;
+                text-decoration: none;
+            }
+
+            &:active {
+                background: @buttonGreenActive;
+            }
+        }
+    }
+}

--- a/routes/main/editor.js
+++ b/routes/main/editor.js
@@ -55,6 +55,10 @@ module.exports = function(config, req, res) {
     qs = "?" + qs;
   }
 
+  // We currently run properly in Firefox, Chrome and Opera, with UI issues in the rest.
+  // Until we sort those out, warn users of these browsers
+  var ua = req.useragent;
+
   var options = {
     appURL: config.appURL,
     csrf: req.csrfToken(),
@@ -62,7 +66,8 @@ module.exports = function(config, req, res) {
     loginURL: config.appURL + "/login",
     logoutURL: config.logoutURL,
     queryString: qs,
-    mainURL: env.get("NODE_ENV") === "development" ? "/editor/scripts/main.js" : "/dist/main.js"
+    mainURL: env.get("NODE_ENV") === "development" ? "/editor/scripts/main.js" : "/dist/main.js",
+    browserNotSupported: !(ua.isFirefox || ua.isChrome || ua.isOpera)
   };
 
   // We add the localization code to the query params through a URL object

--- a/views/editor/bramble.html
+++ b/views/editor/bramble.html
@@ -1,112 +1,125 @@
 {% block bramble %}
-
-
-<style>
-  /*
-  * Initial loading spinner css, inlined so we don't block loading.
-  * Spinner is based on https://github.com/tobiasahlin/SpinKit (MIT)
-  */
-
-    #spinner-container {
-        position: fixed;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        z-index: 999999;
-        background: #0b4326;
-        opacity: .9;
-    }
-
-    #spinner-container .message {
-        top: calc(50% + 40px);
-        width: 100%;
-        position: fixed;
-        text-align: center;
-        color: white;
-        opacity: .6;
-    }
-
-    #spinner-container .error-message {
-      display: none;
-    }
-
-    #spinner-container.loading-error .error-message {
-      display: block;
-    }
-
-    #spinner-container .loading-message {
-        animation: loadingpulse 1s infinite linear;
-    }
-
-    #spinner-container .thimble-spinner {
-        bottom: 0;
-        top: 0;
-        left: 0;
-        right: 0;
-        margin: auto;
-        position: fixed;
-        max-width: 50%;
-        width: 50px;
-        height: 50px;
-        background: url(/img/thimble-icon.svg);
-        background-position: center;
-        background-size: 100%;
-        animation: spinner 2s infinite ease-in-out;
-        outline: 1px solid transparent;
-    }
-
-    #spinner-container.loading-error {
-      background: black;
-    }
-
-    #spinner-container.loading-error .loading-message {
-      display: none;
-    }
-
-    #spinner-container.loading-error .thimble-spinner {
-      animation: none;
-    }
-
-    @keyframes loadingpulse {
-        0% {
-            transform: scale(1);
-            opacity: .4;
+    <style>
+        /*
+        * Initial loading spinner css, inlined so we don't block loading.
+        * Spinner is based on https://github.com/tobiasahlin/SpinKit (MIT)
+        */
+        #spinner-container {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            z-index: 999;
+            background: #0b4326;
+            opacity: .9;
         }
-        50% {
-            transform: scale(1.02);
+
+        #spinner-container .message {
+            top: calc(50% + 40px);
+            width: 100%;
+            position: fixed;
+            text-align: center;
+            color: white;
             opacity: .6;
         }
-        100% {
-            transform: scale(1);
-            opacity: .4;
-        }
-    }
 
-    @keyframes spinner {
-        0% {
-            transform: perspective(120px) rotateX(0deg) rotateY(0deg);
+        #spinner-container .error-message {
+          display: none;
         }
-        25% {
-            transform: perspective(120px) rotateX(-180.1deg) rotateY(0deg);
+
+        #spinner-container.loading-error .error-message {
+          display: block;
         }
-        50% {
-            transform: perspective(120px) rotateX(-180deg) rotateY(-179.9deg);
+
+        #spinner-container .loading-message {
+            animation: loadingpulse 1s infinite linear;
         }
-        75% {
-            transform: perspective(120px) rotateX(-360deg) rotateY(-179.9deg);
+
+        #spinner-container .thimble-spinner {
+            bottom: 0;
+            top: 0;
+            left: 0;
+            right: 0;
+            margin: auto;
+            position: fixed;
+            max-width: 50%;
+            width: 50px;
+            height: 50px;
+            background: url(/img/thimble-icon.svg);
+            background-position: center;
+            background-size: 100%;
+            animation: spinner 2s infinite ease-in-out;
+            outline: 1px solid transparent;
         }
-        100% {
-            transform: perspective(120px) rotateX(-360deg) rotateY(-360deg);
+
+        #spinner-container.loading-error {
+          background: black;
         }
-    }
-</style>
+
+        #spinner-container.loading-error .loading-message {
+          display: none;
+        }
+
+        #spinner-container.loading-error .thimble-spinner {
+          animation: none;
+        }
+
+        @keyframes loadingpulse {
+            0% {
+                transform: scale(1);
+                opacity: .4;
+            }
+            50% {
+                transform: scale(1.02);
+                opacity: .6;
+            }
+            100% {
+                transform: scale(1);
+                opacity: .4;
+            }
+        }
+
+        @keyframes spinner {
+            0% {
+                transform: perspective(120px) rotateX(0deg) rotateY(0deg);
+            }
+            25% {
+                transform: perspective(120px) rotateX(-180.1deg) rotateY(0deg);
+            }
+            50% {
+                transform: perspective(120px) rotateX(-180deg) rotateY(-179.9deg);
+            }
+            75% {
+                transform: perspective(120px) rotateX(-360deg) rotateY(-179.9deg);
+            }
+            100% {
+                transform: perspective(120px) rotateX(-360deg) rotateY(-360deg);
+            }
+        }
+
+    </style>
 
     <div id="spinner-container">
         <div class="thimble-spinner"></div>
         <div class="loading-message message">Loading Project</div>
         <div class="error-message message">There was an error loading your Project. <br>Please refresh your browser.</div>
     </div>
+
+    {% if browserNotSupported %}
+    <div id="browser-support-warning">
+      <div class="message-box">
+        <h1>Oh no!</h1>
+        <p>
+          Thimble doesn't fully support your browser yet, but we're working on it.
+          For now, try Thimble in <a title="Download Mozilla Firefox" href="https://www.mozilla.org/en-US/firefox/new/">Firefox</a>
+          or <a title="Download Google Chrome" href="https://www.google.com/chrome/browser/desktop/index.html">Chrome</a>.
+        </p>
+        <div title="Continue using Thimble" class="let-me-in">I don't care, let me in!</div>
+      </div>
+    </div>
+    {% endif %}
+
     <div class="bramble-toolbar">
         {% include './nav-options.html' %}
     </div>


### PR DESCRIPTION
This is a start, we need proper UI from @flukeout.  I've added the `browser-support-warning` div and css to the `bramble.html` view.