### PR TITLE
Updated the starter project styling - Fixes 1005

### DIFF
--- a/public/homepage/stylesheets/style.less
+++ b/public/homepage/stylesheets/style.less
@@ -406,15 +406,15 @@ footer {
       }
 
       &.keep-calm .image {
-        background: ~"url(/img/thumbnail-keep-calm.png)";
+        background: ~"url(/img/thumbnail-keep-calm.png)"  #8B0208;
       }
 
       &.postcard .image {
-        background: ~"url(/img/thumbnail-postcard.png)";
+        background: ~"url(/img/thumbnail-postcard.png)" #FED831;
       }
 
       &.comic-strip .image {
-        background: ~"url(/img/thumbnail-comic-strip.png)";
+        background: ~"url(/img/thumbnail-comic-strip.png)" #EFEFEF;
       }
 
       .remix-button {

--- a/views/homepage/index.html
+++ b/views/homepage/index.html
@@ -67,7 +67,8 @@
             <div class="project keep-calm">
               <h2 class="title">Keep Calm Poster</h2>
               <div class="thumbnail">
-                <a href="{{ keepCalmRemixUrl }}" title="Remix the Keep Calm Poster project" class="image"></a> </div>
+                <a href="{{ keepCalmRemixUrl }}" title="Remix the Keep Calm Poster project" class="image"></a>
+              </div>
               <p class="description">
                 Change the design of this poster to make it your own.
               </p>
@@ -114,7 +115,7 @@
 
             <!-- Comic Strip Project -->
             <div class="project comic-strip">
-              <h2 class="title">Current Events Comic Strip</h2>
+              <h2 class="title">Current Events Comic</h2>
               <div class="thumbnail">
                 <a href="{{ comicStripRemixUrl }}" title="Remix the Current Events Comic Strip project" class="image"></a>
               </div>


### PR DESCRIPTION
**Changes**
* Removed "Strip" from the Comic Strip title so that the title fits on one line.
* Added a background color behind the project thumbnail images so that
  * It doesn't look as jarring when the images load because there is already a matching background color
  * The weird element that provides the drop shadow is hidden before the thumbnail images load

Fixes #1005 