### PR TITLE
Editor heading bar updates - Fixes #1010

### DIFF
--- a/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
+++ b/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
@@ -10,13 +10,9 @@ define(function(require) {
   var _escKeyHandler;
 
   function updateLayout(data) {
-    // Calculate total width of brackets
-    var total = data.sidebarWidth + data.firstPaneWidth + data.secondPaneWidth;
-
-    // Set width in percent, easier for window resize
-    $(".filetree-pane-nav").width(((data.sidebarWidth / total) * 100) + "%");
-    $(".editor-pane-nav").width(((data.firstPaneWidth / total) * 100) + "%");
-    $(".preview-pane-nav").width(((data.secondPaneWidth / total) * 100) + "%");
+    $(".filetree-pane-nav").width(data.sidebarWidth);
+    $(".editor-pane-nav").width(data.firstPaneWidth);
+    $(".preview-pane-nav").width(data.secondPaneWidth);
   }
 
   function init(bramble, options) {

--- a/public/editor/stylesheets/editor.less
+++ b/public/editor/stylesheets/editor.less
@@ -22,11 +22,11 @@
   position: absolute;
   z-index: 2;
   top: @headerHeight;
-
   height: @toolbarHeight;
   width: 100%;
   margin: 0;
   padding: 0;
+  background: #EAEAEA;
 }
 
 .editor-nav {
@@ -494,8 +494,7 @@
 
 .preview-pane-nav {
   top: 0;
-  left: 50%;
-  width: 50%;
+  position: absolute;
   height: @toolbarHeight;
   z-index: 2;
   background-color: #EAEAEA;
@@ -505,7 +504,7 @@
   .flex-container;
 
   .nav-container {
-    min-width: 330px;
+    min-width: 360px;
   }
 }
 
@@ -514,8 +513,6 @@
   font-weight: bold;
   font-size: 1em;
 }
-
-
 
 #preview-pane-nav-refresh {
   background-color: #F9F9F9;


### PR DESCRIPTION
**Changes**
* Set the editor header column widths by pixels to avoid percentage rounding problems
* Changed the toolbar background to grey so there aren't flashes of white when things are resizing

Tested in FF and Chrome and performance is fine!

Fixes #1010