### PR TITLE
Updated file tray arrow icons - Fixes #946

### DIFF
--- a/public/editor/stylesheets/editor.less
+++ b/public/editor/stylesheets/editor.less
@@ -118,8 +118,7 @@
     opacity: 0.4;
     background-repeat: no-repeat;
     background-position: center;
-    background-size: 10px 10px;
-
+    background-size: 10px;
   }
 
   &:hover {
@@ -226,7 +225,7 @@
     opacity: .2;
     background-repeat: no-repeat;
     background-position: center;
-    background-size: 10px 10px;
+    background-size: 10px;
   }
 
   &:hover div {

--- a/public/resources/img/icon/file-tray-arrow-left.svg
+++ b/public/resources/img/icon/file-tray-arrow-left.svg
@@ -1,17 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns"
-	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="5px" height="8px"
-	 viewBox="0 0 5 8" enable-background="new 0 0 5 8" xml:space="preserve">
-<title>file-tray-arrow</title>
-<desc>Created with Sketch.</desc>
-<g id="Icons" sketch:type="MSPage">
-	<g id="file-tray-arrow" sketch:type="MSArtboardGroup">
-		<path id="Imported-Layers" sketch:type="MSShapeGroup" d="M4.124,7.5c0.108,0,0.2-0.039,0.271-0.116
-			c0.069-0.077,0.104-0.173,0.104-0.282V0.398c0-0.109-0.035-0.203-0.104-0.28C4.324,0.039,4.232,0,4.124,0
-			C4.029,0,3.961,0.025,3.913,0.07L3.866,0.118L0.21,3.306C0.069,3.447,0,3.595,0,3.75c0,0.157,0.069,0.305,0.21,0.446l3.656,3.188
-			L3.936,7.43L4.124,7.5"/>
-	</g>
-</g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="8px" height="8px" viewBox="0 0 8 8" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
+    <!-- Generator: Sketch 3.3.3 (12081) - http://www.bohemiancoding.com/sketch -->
+    <title>file-tray-arrow-left</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Icons" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" sketch:type="MSPage">
+        <g id="file-tray-arrow-left" sketch:type="MSArtboardGroup" fill="#000000">
+            <path d="M1.41199995,0.123733333 C1.33733329,0.206933333 1.29999995,0.308266667 1.29999995,0.424533333 L1.29999995,7.5744 C1.29999995,7.69173333 1.33733329,7.79093333 1.41199995,7.87413333 C1.48666662,7.9584 1.58373329,8 1.69999995,8 C1.80026662,8 1.87386662,7.97333333 1.92506662,7.92426667 L1.97519995,7.87413333 L5.87493329,4.4736 C6.02426662,4.3232 6.09893329,4.16533333 6.09893329,4 C6.09893329,3.83253333 6.02426662,3.67466667 5.87493329,3.52426667 L1.97519995,0.123733333 L1.90053329,0.0746666667 L1.69999995,0 C1.58373329,0 1.48666662,0.0416 1.41199995,0.123733333 Z" id="Imported-Layers" sketch:type="MSShapeGroup" transform="translate(3.699467, 4.000000) rotate(-180.000000) translate(-3.699467, -4.000000) "></path>
+        </g>
+    </g>
 </svg>

--- a/public/resources/img/icon/file-tray-arrow-right.svg
+++ b/public/resources/img/icon/file-tray-arrow-right.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg width="5px" height="8px" viewBox="0 0 5 8" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
-    <!-- Generator: Sketch 3.3.2 (12043) - http://www.bohemiancoding.com/sketch -->
+<svg width="8px" height="8px" viewBox="0 0 8 8" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
+    <!-- Generator: Sketch 3.3.3 (12081) - http://www.bohemiancoding.com/sketch -->
     <title>file-tray-arrow</title>
     <desc>Created with Sketch.</desc>
     <defs></defs>
     <g id="Icons" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" sketch:type="MSPage">
         <g id="file-tray-arrow" sketch:type="MSArtboardGroup" fill="#FFFFFF">
-            <path d="M0.375,0 C0.266,0 0.175,0.039 0.105,0.116 C0.035,0.194 0,0.289 0,0.398 L0,7.101 C0,7.211 0.035,7.304 0.105,7.382 C0.175,7.461 0.266,7.5 0.375,7.5 C0.469,7.5 0.538,7.475 0.586,7.429 L0.633,7.382 L4.289,4.194 C4.429,4.053 4.499,3.905 4.499,3.75 C4.499,3.593 4.429,3.445 4.289,3.304 L0.633,0.116 L0.563,0.07 L0.375,0" id="Imported-Layers" sketch:type="MSShapeGroup"></path>
+            <path d="M2.112,0.123733333 C2.03733333,0.206933333 2,0.308266667 2,0.424533333 L2,7.5744 C2,7.69173333 2.03733333,7.79093333 2.112,7.87413333 C2.18666667,7.9584 2.28373333,8 2.4,8 C2.50026667,8 2.57386667,7.97333333 2.62506667,7.92426667 L2.6752,7.87413333 L6.57493333,4.4736 C6.72426667,4.3232 6.79893333,4.16533333 6.79893333,4 C6.79893333,3.83253333 6.72426667,3.67466667 6.57493333,3.52426667 L2.6752,0.123733333 L2.60053333,0.0746666667 L2.4,0 C2.28373333,0 2.18666667,0.0416 2.112,0.123733333 Z" id="Imported-Layers" sketch:type="MSShapeGroup"></path>
         </g>
     </g>
 </svg>


### PR DESCRIPTION
Changed the icons and style a bit so they appear the same in Firefox and Chrome.

Fixes #946