### PR TITLE
Fix regression - Show 'Untitled Project' when creating a new project as a signed in user

### DIFF
--- a/public/editor/scripts/project/project.js
+++ b/public/editor/scripts/project/project.js
@@ -108,11 +108,12 @@ define(function(require) {
     Metadata.getTitle(metadataLocation, function(err, title) {
       if (err) {
         if (err.code !== "ENOENT") {
-          return callback(err);
-        } else if (!_user && err.code === "ENOENT") {
+          callback(err);
+        } else {
           _title = projectDetails.title;
-          return callback();
+          callback();
         }
+        return;
       }
 
       if (_user) {


### PR DESCRIPTION
Seems like I introduced a regression with 224ddda. When we create a new project/remix a project as an authenticated user, we lose the project title. This PR makes it so that we check to see if we can get the project title from the project root, if not, we should use what the server sends us.