### PR TITLE
Fix #1031: warn users of failed filesystem operations in private browsing mode

### DIFF
--- a/public/editor/scripts/editor/js/bramble-editor.js
+++ b/public/editor/scripts/editor/js/bramble-editor.js
@@ -28,7 +28,6 @@ define(function(require) {
       // Start loading the Bramble editor resources
       Bramble.load("#webmaker-bramble",{
         url: options.editorUrl,
-        autoRecoverFileSystem: true,
         hideUntilReady: true
       });
 

--- a/views/editor/bramble.html
+++ b/views/editor/bramble.html
@@ -103,7 +103,11 @@
     <div id="spinner-container">
         <div class="thimble-spinner"></div>
         <div class="loading-message message">Loading Project</div>
-        <div class="error-message message">There was an error loading your Project. <br>Please refresh your browser.</div>
+        <div class="error-message message">
+            <p>There was an error loading your Project.<br>
+            Please refresh your browser.</p>
+            <p>NOTE: if you are using Private Browsing mode, please reload in normal mode.</p>
+        </div>
     </div>
 
     <div id="browser-support-warning" class="hide">


### PR DESCRIPTION
This builds on https://github.com/humphd/brackets/pull/455 and causes us to error when the user is in private browsing mode.  We no longer try to auto recover a failed indexeddb, and that's because we can't do that and warn.  I think the errors we're hearing about in the wild are not corruption, but rather private browsing mode in ff.  This should make things better, since they'll get some info instead of a loading screen that never ends.