### PR TITLE
Fix #1064 - project TAR file gets corrupted, can't be parsed in IE

### DIFF
--- a/public/editor/scripts/main.js
+++ b/public/editor/scripts/main.js
@@ -18,7 +18,18 @@ require.config({
   }
 });
 
-(function() {
+require(["jquery", "bowser"], function($, bowser) {
+  // Temporary check while we finish cross-browser work. We are known
+  // to run well in Firefox, Chrome, Opera, but not Safari or IE.
+  if(bowser.msie || bowser.msedge || bowser.safari) {
+    $("#browser-support-warning").removeClass("hide");
+
+    $(".let-me-in").on("click", function(e) {
+      $("#browser-support-warning").fadeOut();
+      return false;
+    });
+  }
+
   function onError(err) {
     console.error("[Bramble Error]", err);
     $("#spinner-container").addClass("loading-error");
@@ -60,18 +71,5 @@ require.config({
     });
   }
 
-  require(["jquery", "bowser"], function($, bowser) {
-    // Temporary check while we finish cross-browser work. We are known
-    // to run well in Firefox, Chrome, Opera, but not Safari, IE.
-    if(!(bowser.firefox || bowser.chrome || bowser.opera)) {
-      $("#browser-support-warning").removeClass("hide");
-
-      $(".let-me-in").on("click", function(e) {
-        $("#browser-support-warning").fadeOut();
-        return false;
-      });
-    }
-
-    require(["bramble-editor", "project", "sso-override", "fc/project-rename"], init);
-  });
-}());
+  require(["bramble-editor", "project", "sso-override", "fc/project-rename"], init);
+});

--- a/routes/files/read/data.js
+++ b/routes/files/read/data.js
@@ -1,7 +1,9 @@
 var utils = require("../../utils");
 
 function sendResponse(res, tarStream) {
-  res.type("application/x-tar");
+  // NOTE: this should be `application/x-tar`, but IE won't decompress the
+  // stream if we use that.  With `application/octet-stream` it works everywhere.
+  res.type("application/octet-stream");
   tarStream
   .on("error", function(err) {
     console.error("Failed to stream tar with: ", err);


### PR DESCRIPTION
This switches our content-type for the project tarball to be something IE can handle (i.e., will decompress).  I've also fixed a load ordering bug in our error handling, where jquery wasn't in scope yet.  Finally, I adjusted the checks for browsers we don't support.  These are temporary, and we can remove them once the UI gets updated.