### PR TITLE
Fix #1060 - deal with browsers not supporting String.prototype.endsWith()

### DIFF
--- a/public/editor/scripts/project/remote.js
+++ b/public/editor/scripts/project/remote.js
@@ -110,7 +110,7 @@ define(function(require) {
     }
 
     function upgradeFile(path, next) {
-      if (path.endsWith('/')) {
+      if (path.match(/\/$/)) {
         return next();
       }
 


### PR DESCRIPTION
See https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith#Browser_compatibility.  I also wonder if this will fix #883