### PR TITLE
Remove warning for all modern browsers, warn for < IE 11 and < Safari 8

### DIFF
--- a/public/editor/scripts/main.js
+++ b/public/editor/scripts/main.js
@@ -19,9 +19,9 @@ require.config({
 });
 
 require(["jquery", "bowser"], function($, bowser) {
-  // Temporary check while we finish cross-browser work. We are known
-  // to run well in Firefox, Chrome, Opera and Safari but not IE.
-  if(bowser.msie || bowser.msedge) {
+  // Warn users of unsupported browsers that they can try something newer,
+  // specifically anything before IE 11 or Safari 8.
+  if((bowser.msie && bowser.version < 11) || (bowser.safari && bowser.version < 8)) {
     $("#browser-support-warning").removeClass("hide");
 
     $(".let-me-in").on("click", function(e) {

--- a/views/editor/bramble.html
+++ b/views/editor/bramble.html
@@ -127,13 +127,11 @@
 
     <div id="browser-support-warning" class="hide">
       <div class="message-box">
-        <h1>Oh no!</h1>
+        <h1>Sorry, Thimble won't work in your Browser</h1>
         <p>
-          Thimble doesn't fully support your browser yet, but we're working on it.
-          For now, try Thimble in <a title="Download Mozilla Firefox" href="https://www.mozilla.org/en-US/firefox/new/">Firefox</a>
-          or <a title="Download Google Chrome" href="https://www.google.com/chrome/browser/desktop/index.html">Chrome</a>.
+          Thimble works in all of the following browsers: <a title="Download Mozilla Firefox" href="https://www.mozilla.org/en-US/firefox/new/">Firefox</a>, <a title="Download Google Chrome" href="https://www.google.com/chrome/browser/desktop/index.html">Chrome</a>, Internet Explorer 11, Microsoft Edge, Safari (8+), and <a title="Download Opera" href="http://www.opera.com/download">Opera</a>.
         </p>
-        <div title="Continue using Thimble" class="let-me-in">I don't care, let me in!</div>
+        <div title="Continue using Thimble" class="let-me-in">Let me try anyway!</div>
       </div>
     </div>
 


### PR DESCRIPTION
This removes the IE/Edge warning, and adjusts things to only warn for IE 10, etc. and earlier versions of Safari.