### PR TITLE
Run grunt without a path in the postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "webmaker-translation-stats": "0.0.1"
   },
   "scripts": {
-    "postinstall": "node_modules/.bin/bower install && node_modules/.bin/grunt requirejs:dist",
+    "postinstall": "node_modules/.bin/bower install && grunt requirejs:dist",
     "test": "node_modules/.bin/grunt",
     "start": "node app.js"
   }


### PR DESCRIPTION
Fixes #1128 on Windows but needs testing on other platforms (linux / osx)