### PR TITLE
[WIP] Fixed #1132 - Invalidate CloudFront edge caches on a prod deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,9 @@ deploy:
   on:
     repo: mozilla/thimble.webmaker.org
     branch: bramble
+after_deploy:
+  - node invalidate.js
+env:
+  - CLOUDFRONT_DISTRIBUTION_ID="E25G9W2D0007RH"
+  - secure: "UZWFTvdsfT77fn2SG8wVomv2EYXVKAvJWtg/JeLds7i31HHD6mWBWP5/7+E5E9quMfbrVVBtiPukXIdv+leduVbBVMzdSy/oMVItk0/sKwe9m8s90pmvKBbbaX0MDPtwJ61xmoOVPlNFtjZfBu+HqY0yWKQ3oHYOA2UpqFRgVqI="
+  - secure: "KpSpWNrkHJtsSNgVrnQZeBgxXiy6HACLDhITS/uE9EXaq5VLQE8zjZUTXtFyRmvo4AINYPZFi+N2lvSgA8Kkxq4fk7PrYYvOfr/vhhbOW/gdIPa/9dMTsDcnXkfLgjMMUj1XN1tWBDLBYl1NZ51H02HrvKZC+gBG1TkVaPJnm6k="

--- a/invalidate.js
+++ b/invalidate.js
@@ -1,0 +1,43 @@
+/**
+ * This file is a short script that invalidates
+ * the cloudfront edge caches for Thimble whenever
+ * we deploy a new version.
+ */
+var AWS = require('aws-sdk');
+AWS.config.update({
+  // These variables are encrypted in the .travis.yml file
+  accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+  secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY
+});
+
+var cloudfront = AWS.CloudFront();
+
+// We can't do conditional logic in travis hooks, so
+// we detect the branch we're on and bail out early if
+// this is a staging deploy. Only production uses CloudFront
+if (process.env.TRAVIS_BRANCH === 'bramble') {
+  return process.exit(0);
+}
+
+var params = {
+  DistributionId: process.env.CLOUDFRONT_DISTRIBUTION_ID,
+  InvalidationBatch: {
+    // Use the commit hash as the unique identifier for this invalidation
+    CallerReference: process.env.TRAVIS_COMMIT,
+    Paths: {
+      Quantity: 1,
+      // We invalidate everything on deploy
+      Items: [ '/*' ]
+    }
+  }
+};
+
+cloudfront.createInvalidation(params, function(err, data) {
+  if (err) {
+    console.log(err, err.stack);
+    return process.exit(1);
+  }
+
+  console.log('Successfully invalidated CloudFront!\n', data);
+  process.exit(0);
+});

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "async": "0.2.7",
+    "aws-sdk": "^2.2.4",
     "body-parser": "^1.13.1",
     "bower": "1.3.8",
     "browserify": "^10.2.4",


### PR DESCRIPTION
This patch adds automatic invalidation of the CloudFront edge caches for Thimble whenever we deploy to production

To be completed:

* [x] Encrypting AWS api key as secure variables in the `.travis.yml` file
