### PR TITLE
Fix #1155 - support event based and manual closing the popup menu.

### DIFF
--- a/public/editor/scripts/editor/js/fc/bramble-popupmenu.js
+++ b/public/editor/scripts/editor/js/fc/bramble-popupmenu.js
@@ -20,8 +20,9 @@ define(function(require) {
     }
 
     self.close = function(e) {
-      e.stopPropagation();
-
+      if(e) {
+        e.stopPropagation();
+      }
       if(!self.showing) {
         return;
       }


### PR DESCRIPTION
There are two code paths where `self.close` can get called, only one of which has an event object that needs to be stopped from propagating.  This adds support for the manual call, with no event object.