### PR TITLE
Fix #1092 - store file sync state info in the project root xattrib

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -45,12 +45,15 @@ module.exports = function( grunt ) {
           paths: {
             "bowser": "../../../../resources/scripts/vendor/bowser",
             "sso-override": "../../sso-override",
+            "logger": "../../logger",
             "jquery": "../../../../../bower_components/jquery/index",
             "localized": "../../../../../bower_components/webmaker-i18n/localized",
             "uuid": "../../../../../bower_components/node-uuid/uuid",
             "cookies": "../../../../../bower_components/cookies-js/dist/cookies",
             "project": "../../project/project",
-            "constants": "../../constants"
+            "PathCache": "../../path-cache",
+            "constants": "../../constants",
+            "EventEmitter": "../../../../../bower_components/eventEmitter/EventEmitter.min"
           },
           shim: {
             "jquery": {
@@ -125,11 +128,10 @@ module.exports = function( grunt ) {
         },
         files: {
           src: [
-            // Temporary, until we shift entirely to browserify
-            "public/scripts/**/*.js",
-            "!public/scripts/editor/vendor/*.js",
-            "frontend/src/scripts/**/*.js",
-            "frontend/src/scripts/*.js"
+            "public/editor/**/*.js",
+            "public/homepage/**/*.js",
+            "!public/homepage/scripts/google-analytics.js",
+            "!public/editor/scripts/google-analytics.js"
           ]
         }
       }

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,7 @@
 {
   "name": "thimble.webmaker.org",
   "dependencies": {
+    "eventEmitter": "~4.3.0",
     "jquery": "http://code.jquery.com/jquery-2.1.4.min.js",
     "cookies-js": "~1.2.1",
     "node-uuid": "~1.4.3",

--- a/public/editor/scripts/constants.js
+++ b/public/editor/scripts/constants.js
@@ -1,6 +1,11 @@
 define(function() {
   return {
     ANONYMOUS_USER_FOLDER: "/.anonymous/projects",
-    PROJECT_META_KEY: "thimble-project-meta"
+    PROJECT_META_KEY: "thimble-project-meta",
+    SYNC_OPERATION_UPDATE: "update",
+    SYNC_OPERATION_DELETE: "delete",
+    // Timer for how often to empty the sync queue if not explicitly asked to do so
+    SYNC_TIMEOUT_MS: 10 * 1000,
+    CACHE_KEY_PREFIX: "thimble-cache-key-"
   };
 });

--- a/public/editor/scripts/editor/js/fc/filesystem-sync.js
+++ b/public/editor/scripts/editor/js/fc/filesystem-sync.js
@@ -1,314 +1,84 @@
+/**
+ * The FileSystemSync module connects the Bramble editor's file system change events
+ * to the PathCache and SyncManager, making sure that all changes to local files
+ * get recorded and eventually sent to the server.
+ */
+
 define(function(require) {
   var $ = require("jquery");
   var Project = require("project");
-  var FileSystemSync = {};
+  var SyncManager = require("fc/sync-manager");
+  var SyncState = require("fc/sync-state");
 
-  function hideFileState(remainingFiles) {
-    if(!remainingFiles) {
-      $("#navbar-save-indicator").addClass("hide");
-    }
-  }
+  var syncManager;
+  var brambleInstance;
 
-  function triggerCallbacks(callbacks, args) {
-    callbacks.forEach(function(callback) {
-      callback.apply(null, args);
-    });
-  }
-
-  function fileChange(csrfToken, fs, path, callback) {
-    var options = {
-      headers: {
-        "X-Csrf-Token": csrfToken
-      },
-      type: "PUT",
-      url: Project.getHost() + "/projects/" + Project.getID() + "/files",
-      cache: false,
-      contentType: false,
-      processData: false
-    };
-
-    function send(id) {
-      var request;
-
-      if(id) {
-        options.url = options.url + "/" + id;
-      }
-
-      request = $.ajax(options);
-      request.done(function() {
-        if(request.status !== 201 && request.status !== 200) {
-          return callback(new Error("[Bramble] Server did not persist " + path + ". Server responded with status " + request.status));
-        }
-
-        var data = request.responseJSON;
-        Project.setFileID(path, data.id, callback);
-      });
-      request.fail(function(jqXHR, status, err) {
-        console.error("[Bramble] Failed to send request to persist the file to the server with: ", err);
-        callback(err);
-      });
+  function saveAndSyncAll(callback) {
+    if(!(brambleInstance && syncManager)) {
+      callback(new Error("[Thimble Error] saveAndSyncAll() called before init()"));
+      return;
     }
 
-    fs.readFile(path, function(err, data) {
-      if(err) {
-        return callback(err);
-      }
-
-      options.data = FileSystemSync.toFormData(path, data);
-      Project.getFileID(path, function(err, id) {
-        if(err) {
-          return callback(err);
-        }
-        send(id);
-      });
+    brambleInstance.saveAll(function() {
+      syncManager.once("complete", callback);
+      syncManager.sync();
     });
   }
 
-  function handleFileChange(csrfToken, fs, path) {
-    var context = this;
-    context.queueLength++;
-
-    fileChange(csrfToken, fs, path, function(err) {
-      context.queueLength--;
-      hideFileState(context.queueLength);
-      triggerCallbacks(context._callbacks.afterEach, [err, path]);
-    });
-  }
-
-  function fileDelete(csrfToken, fs, path, callback) {
-    function doDelete(id) {
-      var request = $.ajax({
-        contentType: "application/json",
-        headers: {
-          "X-Csrf-Token": csrfToken
-        },
-        type: "DELETE",
-        url: Project.getHost() + "/projects/" + Project.getID() + "/files/" + id + "?dateUpdated=" + (new Date()).toISOString(),
-      });
-      request.done(function() {
-        if(request.status !== 200) {
-          return callback(new Error("[Thimble] Server did not persist " + path + ". Server responded with status " + request.status));
-        }
-
-        Project.removeFile(path, callback);
-      });
-      request.fail(function(jqXHR, status, err) {
-        console.error("[Thimble] Failed to send request to delete the file to the server with: ", err);
-        callback(err);
-      });
-    }
-
-    Project.getFileID(path, function(err, id) {
-      if(err) {
-        return callback(err);
-      }
-
-      doDelete(id);
-    });
-  }
-
-  function handleFileDelete(csrfToken, fs, path) {
-    var context = this;
-    context.queueLength++;
-
-    fileDelete(csrfToken, fs, path, function(err) {
-      context.queueLength--;
-      hideFileState(context.queueLength);
-      triggerCallbacks(context._callbacks.afterEach, [err, path]);
-    });
-  }
-
-  // Two part process (create + delete), which can be done in parallel
-  function handleFileRename(csrfToken, fs, oldFilename, newFilename) {
-    var context = this;
-
-    // Step 1: Create the new file
-    context.queueLength++;
-    fileChange(csrfToken, fs, newFilename, function(err) {
-      context.queueLength--;
-      hideFileState(context.queueLength);
-      triggerCallbacks(context._callbacks.afterEach, [err, newFilename]);
-    });
-
-    // Step 2: Delete the old file
-    context.queueLength++;
-    fileDelete(csrfToken, fs, oldFilename, function(err) {
-      context.queueLength--;
-      hideFileState(context.queueLength);
-      triggerCallbacks(context._callbacks.afterEach, [err, oldFilename]);
-    });
-  }
-
-  function FSync() {
-    this.queueLength = 0;
-    // Holds a list of callbacks that can be attached
-    // using `fsync.addBeforeEachCallback` and `fsync.addAfterEachCallback`
-    // and will run before and after (respectively) a file
-    // change/delete/rename has been pushed up to the publish server.
-    this._callbacks = {
-      beforeEach: [],
-      afterEach: []
-    };
-  }
-
-  FileSystemSync.init = function(csrfToken) {
+  function init(csrfToken) {
     // If an anonymous user is using thimble, they
     // will not have any persistence of files
     if(!Project.getUser()) {
       return null;
     }
 
-    var fsync = new FSync();
-    var fs = Bramble.getFileSystem();
+    syncManager = SyncManager.init(csrfToken);
 
-    function configHandler(handler) {
-      return function() {
-        triggerCallbacks(fsync._callbacks.beforeEach, arguments);
-
-        Array.prototype.unshift.call(arguments, csrfToken, fs);
-        handler.apply(fsync, arguments);
-      };
-    }
-
-    fsync.handlers = {
-      change: configHandler(handleFileChange),
-      del: configHandler(handleFileDelete),
-      rename: configHandler(handleFileRename)
-    };
-
-    Bramble.once("ready", function(bramble) {
-      fsync.bramble = bramble;
-
-      bramble.on("fileChange", fsync.handlers.change);
-      bramble.on("fileDelete", fsync.handlers.del);
-      bramble.on("fileRename", fsync.handlers.rename);
+    // Update the UI with a "Saving..." indicator whenever we sync a file
+    syncManager.on("file-sync-start", function() {
+      $("#navbar-save-indicator").removeClass("hide");
+    });
+    syncManager.on("file-sync-stop", function() {
+      $("#navbar-save-indicator").addClass("hide");
     });
 
-    return fsync;
+    // Warn the user when we're syncing so they don't close the window by accident
+    syncManager.on("sync-start", function() {
+      SyncState.syncing();
+    });
+    syncManager.on("complete", function() {
+      SyncState.completed();
+    });
+
+    Bramble.once("ready", function(bramble) {
+      function handleFileChange(path) {
+        Project.queueFileUpdate(path);
+      }
+
+      function handleFileDelete(path) {
+        Project.queueFileDelete(path);
+      }
+
+      function handleFileRename(oldFilename, newFilename) {
+        // Step 1: Create the new file
+        Project.queueFileUpdate(newFilename);
+        // Step 2: Delete the old file
+        Project.queueFileDelete(oldFilename);
+      }
+
+      bramble.on("fileChange", handleFileChange);
+      bramble.on("fileDelete", handleFileDelete);
+      bramble.on("fileRename", handleFileRename);
+
+      // Begin autosyncing
+      syncManager.start();
+
+      brambleInstance = bramble;
+    });
+  }
+
+  return {
+    init: init,
+    saveAndSyncAll: saveAndSyncAll
   };
-
-  /**
-   * Static helper for construcitng a FormData object from file info.
-   */
-  FileSystemSync.toFormData = function(path, buffer, dateUpdated) {
-    dateUpdated = dateUpdated || (new Date()).toISOString();
-
-    var formData = new FormData();
-    formData.append("dateUpdated", dateUpdated);
-    formData.append("bramblePath", Project.stripRoot(path));
-    // Don't worry about actual mime type, just treat as binary
-    var blob = new Blob([buffer], {type: "application/octet-stream"});
-    formData.append("brambleFile", blob);
-
-    return formData;
-  };
-
-  FSync.prototype.saveAndSyncAll = function(callback) {
-    var fsync = this;
-    var bramble = fsync.bramble;
-    var afterEach = fsync._callbacks.afterEach;
-    var filesSaved = [];
-
-    function resetAfterEach(fn) {
-      var index = afterEach.indexOf(fn);
-      if(index !== -1) {
-        afterEach.splice(index, 1);
-      }
-    }
-
-    function maybeFinish(err, path) {
-      function finish() {
-        resetAfterEach(maybeFinish);
-        bramble.on("fileChange", fsync.handlers.change);
-        callback.apply(null, arguments);
-      }
-
-      if(err) {
-        finish(err, path);
-        return;
-      }
-
-      if(path) {
-        filesSaved.splice(filesSaved.indexOf(path), 1);
-      }
-
-      if(filesSaved.length === 0) {
-        finish();
-      }
-    }
-
-    function syncAll() {
-      if(filesSaved.length === 0) {
-        maybeFinish();
-        return;
-      }
-
-      fsync.addAfterEachCallback(maybeFinish);
-      filesSaved.forEach(function(path) {
-        fsync.handlers.change(path);
-      });
-    }
-
-    function cacheFilePaths(path) {
-      filesSaved.push(path);
-    }
-
-    function maybeContinue(err) {
-      if(err) {
-        resetAfterEach(maybeContinue);
-        callback(err);
-        return;
-      }
-
-      if(fsync.queueLength > 0) {
-        return;
-      }
-
-      resetAfterEach(maybeContinue);
-      bramble.off("fileChange", fsync.handlers.change);
-      bramble.on("fileChange", cacheFilePaths);
-
-      bramble.saveAll(function() {
-        bramble.off("fileChange", cacheFilePaths);
-        syncAll();
-      });
-    }
-
-    // If there are syncs queued up, wait on them
-    if(fsync.queueLength > 0) {
-      fsync.addAfterEachCallback(maybeContinue);
-    } else {
-      maybeContinue();
-    }
-  };
-
-  // Add a callback to execute before every sync
-  // Each callback receives a `path` as an argument
-  FSync.prototype.addBeforeEachCallback = function(callback) {
-    this._callbacks.beforeEach.push(callback);
-  };
-
-  FSync.prototype.removeBeforeEachCallback = function(callback) {
-    var location = this._callbacks.beforeEach.indexOf(callback);
-
-    if (location !== -1) {
-      this._callbacks.beforeEach.splice(location, 1);
-    }
-  };
-
-  // Add a callback to execute after every successful sync
-  // Each callback receives `error` and `path` as arguments
-  FSync.prototype.addAfterEachCallback = function(callback) {
-    this._callbacks.afterEach.push(callback);
-  };
-
-  FSync.prototype.removeAfterEachCallback = function(callback) {
-    var location = this._callbacks.afterEach.indexOf(callback);
-
-    if (location !== -1) {
-      this._callbacks.afterEach.splice(location, 1);
-    }
-  };
-
-  return FileSystemSync;
 });

--- a/public/editor/scripts/editor/js/fc/project-rename.js
+++ b/public/editor/scripts/editor/js/fc/project-rename.js
@@ -56,8 +56,8 @@ define(function(require) {
 
           //add or remove the 'disabled' class based on if length is 0
           //and also add or remove the click listener
-          context.saveButton[nameLength == 0 ? "addClass" : "removeClass"]("disabled");
-          context.saveButton[nameLength == 0 ? "off" : "on"]("click", saveClicked);
+          context.saveButton[nameLength === 0 ? "addClass" : "removeClass"]("disabled");
+          context.saveButton[nameLength === 0 ? "off" : "on"]("click", saveClicked);
         })
       };
 

--- a/public/editor/scripts/editor/js/fc/sync-manager.js
+++ b/public/editor/scripts/editor/js/fc/sync-manager.js
@@ -1,0 +1,371 @@
+/**
+ * The SyncQueue keeps track of sync operations to be performed on paths.
+ * This currently includes UPDATE and DELETE operations (create, update, delete
+ * and rename are all done using these two). The data structure looks like this:
+ *
+ * syncQueue = {
+ *   current: {
+ *     path: "/path/to/file/being/synced",
+ *     operation: "update"
+ *   },
+ *   pending: {
+ *     "/path/to/file/needing/sync": "update",
+ *     "/path/to/another/file/needing/sync": "delete",
+ *     ...
+ *   }
+ * }
+ *
+ * The `syncQueue.pending` object stores a backlog of paths and operations to be
+ * synced. The `syncQueue.current` object is the file and operation currently being
+ * done, or the one that was in process when the app was stopped/crashed/closed.
+ *
+ * The sync service picks a path at random from the `pending` list and moves it to
+ * `current`, before saving this sync state. Then it tries to do what is in `current`
+ * and if it works, it clears `current` and repeats the process.  If it fails, the
+ * path and operation in current are moved back to pending, and the process repeats.
+ *
+ * In order to avoid races between the SyncManager and the editor's file update events,
+ * a second data structure stores the latest path operations (i.e., events from editor):
+ * the PathCache.  The PathCache needs to be transfered to the SyncQueue at regular
+ * intervals.
+ */
+
+define(function(require) {
+  var $ = require("jquery");
+  var EventEmitter = require("EventEmitter");
+  var SYNC_OPERATION_UPDATE = require("constants").SYNC_OPERATION_UPDATE;
+  var SYNC_OPERATION_DELETE = require("constants").SYNC_OPERATION_DELETE;
+  var SYNC_TIMEOUT_MS = require("constants").SYNC_TIMEOUT_MS;
+  var Project = require("project");
+  var PathCache = require("PathCache");
+  var logger = require("logger");
+
+  // SyncManager instance
+  var _instance;
+
+  function bufferToFormData(path, buffer, dateUpdated) {
+    dateUpdated = dateUpdated || (new Date()).toISOString();
+
+    var formData = new FormData();
+    formData.append("dateUpdated", dateUpdated);
+    formData.append("bramblePath", Project.stripRoot(path));
+    // Don't worry about actual mime type, just treat as binary
+    var blob = new Blob([buffer], {type: "application/octet-stream"});
+    formData.append("brambleFile", blob);
+
+    return formData;
+  }
+
+  
+  function SyncManager(csrfToken) {
+    this.csrfToken = csrfToken;
+    this.fs = Bramble.getFileSystem();
+
+    // The number of file paths yet to be synced
+    this.pendingCount = 0;
+
+    // Whether or not we are currently syncing
+    this.syncing = false;
+  }
+  SyncManager.prototype = new EventEmitter();
+  SyncManager.prototype.constructor = SyncManager;
+
+  SyncManager.init = function(csrfToken) {
+    _instance = new SyncManager(csrfToken);
+    return _instance;
+  };
+
+  SyncManager.getInstance = function() {
+    return _instance;
+  };
+
+  // Start the autosync interval.
+  SyncManager.prototype.start = function() {
+    if(this._interval) {
+      return;
+    }
+    this._interval = setInterval(this.sync.bind(this), SYNC_TIMEOUT_MS);
+  };
+
+  SyncManager.prototype.emitProgressEvent = function() {
+    var pendingCount = this.pendingCount;
+
+     // Emit either a `complete` event or a `pending` event depending on queue length.
+    if(pendingCount === 0) {
+      logger("SyncManager", "complete event");
+      this.trigger("complete");
+    } else {
+      logger("SyncManager", "progress event - pending paths to sync:", pendingCount);
+      this.trigger("progress", [pendingCount]);
+    }
+  };
+  SyncManager.prototype.emitErrorEvent = function(err) {
+    this.setSyncing(false);
+    this.trigger("error", [err]);
+    logger("SyncManager", "error event", err);
+
+    // Try running the operation again, or the next one at least
+    this.runNextOperation();
+  };
+
+  SyncManager.prototype.setPendingCount = function(syncQueue) {
+    this.pendingCount = Object.keys(syncQueue.pending).length;
+  };
+  SyncManager.prototype.getPendingCount = function() {
+    return this.pendingCount;
+  };
+
+  // Perform an AJAX update operation for a given path and file
+  SyncManager.prototype.updateOperation = function(path, callback) {
+    var self = this;
+    var csrfToken = self.csrfToken;
+    var fs = self.fs;
+
+    var options = {
+      headers: {
+        "X-Csrf-Token": csrfToken
+      },
+      type: "PUT",
+      url: Project.getHost() + "/projects/" + Project.getID() + "/files",
+      cache: false,
+      contentType: false,
+      processData: false
+    };
+
+    function send(id) {
+      var request;
+
+      if(id) {
+        options.url = options.url + "/" + id;
+      }
+
+      request = $.ajax(options);
+      request.done(function() {
+        if(request.status !== 201 && request.status !== 200) {
+          return callback(new Error("[Thimble] unable to persist `" + path + "`. Server responded with status " + request.status));
+        }
+
+        var data = request.responseJSON;
+        Project.setFileID(path, data.id, callback);
+      });
+      request.fail(function(jqXHR, status, err) {
+        logger("SyncManager", "unable to persist the file update to the server", err);
+        callback(err);
+      });
+    }
+
+    fs.readFile(path, function(err, data) {
+      if(err) {
+        return callback(err);
+      }
+
+      options.data = bufferToFormData(path, data);
+      Project.getFileID(path, function(err, id) {
+        if(err) {
+          return callback(err);
+        }
+        send(id);
+      });
+    });
+  };
+
+  // Perform an AJAX delete operation for a given path and file
+  SyncManager.prototype.deleteOperation = function(path, callback) {
+    var self = this;
+    var csrfToken = self.csrfToken;
+
+    function doDelete(id) {
+      var request = $.ajax({
+        contentType: "application/json",
+        headers: {
+          "X-Csrf-Token": csrfToken
+        },
+        type: "DELETE",
+        url: Project.getHost() + "/projects/" + Project.getID() + "/files/" + id + "?dateUpdated=" + (new Date()).toISOString(),
+      });
+      request.done(function() {
+        if(request.status !== 200) {
+          return callback(new Error("[Thimble] unable to persist `" + path + "`. Server responded with status " + request.status));
+        }
+
+        Project.removeFile(path, callback);
+      });
+      request.fail(function(jqXHR, status, err) {
+        logger("SyncManager", "unable to persist the file delete to the server", err);
+        callback(err);
+      });
+    }
+
+    Project.getFileID(path, function(err, id) {
+      if(err) {
+        return callback(err);
+      }
+
+      doDelete(id);
+    });
+  };
+
+  // Run an operation in the SyncQueue, and return the number of pending operations after it
+  // completes on the callback.  Throughout the process we work hard to keep the SyncQueue
+  // saved to disk. We also transfer anything in the PathCache into the SyncQueue, restart
+  // old syncs, re-queue failed operations, etc. in an effort to not lose any sync data.
+  SyncManager.prototype.runNextOperation = function() {
+    var self = this;
+    var currentPath;
+    var currentOperation;
+
+    self.setSyncing(true);
+
+    function finalizeOperation(ajaxError) {
+      Project.getSyncQueue(function(err, syncQueue) {
+        if(err) {
+          self.emitErrorEvent(err);
+          return;
+        }
+
+        function finish() {
+          // Operation synced successfully, remove it and save the SyncQueue.
+          delete syncQueue.current;
+
+          Project.setSyncQueue(syncQueue, function(err) {
+            if(err) {
+              self.emitErrorEvent(err);
+              return;
+            }
+
+            self.setPendingCount(syncQueue);
+
+            // If there are more files to sync, run the next one
+            if(self.getPendingCount() > 0) {
+              self.runNextOperation();
+            } else {
+              self.setSyncing(false);
+            }
+          });
+        }
+
+        function queueOperation() {
+          if(currentOperation === SYNC_OPERATION_UPDATE) {
+            Project.queueFileUpdate(currentPath);
+          } else if(currentOperation === SYNC_OPERATION_DELETE) {
+            Project.queueFileDelete(currentPath);
+          } else {
+            self.emitErrorEvent(new Error("[Thimble Error] unknown sync operation:" + currentOperation));
+          }
+        }
+
+        // If the network operation errored, put this file operation back in the pending list
+        if(ajaxError) {
+          logger("SyncManager", "error syncing file, requeuing operation", ajaxError);
+          queueOperation();
+        }
+
+        finish();
+      });
+    }
+
+    function runCurrent() {
+      logger("SyncManager", "starting sync", currentPath, currentOperation);
+
+      if(currentOperation === SYNC_OPERATION_UPDATE) {
+        self.updateOperation(currentPath, finalizeOperation);
+      } else if(currentOperation === SYNC_OPERATION_DELETE) {
+        self.deleteOperation(currentPath, finalizeOperation);
+      } else {
+        self.emitErrorEvent(new Error("[Thimble Error] unknown sync operation:" + currentOperation));
+      }
+      self.emitProgressEvent();
+    }
+
+    function selectCurrent(syncQueue) {
+      // Add any cached operations to the queue, which have recently come in.
+      syncQueue = PathCache.transferToSyncQueue(syncQueue);
+      self.setPendingCount(syncQueue);
+
+      // If there are no pending paths to sync, we're done.
+      if(self.pendingCount === 0) {
+        logger("SyncManager", "no pending sync operations, stopping syncing.");
+        self.emitProgressEvent();
+        self.setSyncing(false);
+        return;
+      }
+
+      // Select and sync a path from the pending list
+      var paths = Object.keys(syncQueue.pending);
+      currentPath = paths[0];
+      currentOperation = syncQueue.pending[currentPath];
+
+      // Update current to the new path/operation, and remove from pending
+      syncQueue.current = {
+        path: currentPath,
+        operation: currentOperation
+      };
+      delete syncQueue.pending[currentPath];
+
+      // Persist this sync info to disk before going further so we can recover
+      // if there's a crash or other failure.
+      Project.setSyncQueue(syncQueue, function(err) {
+        if(err) {
+          self.emitErrorEvent(err);
+          return;
+        }
+
+        self.setPendingCount(syncQueue);
+        runCurrent();
+      });
+    }
+
+    function pickCurrentOperation(err, syncQueue) {
+      if(err) {
+        self.emitErrorEvent(err);
+        return;
+      }
+
+      self.setPendingCount(syncQueue);
+
+      // If there's already a current operation in the queue, restart it
+      // since it probably means the browser shutdown before it could complete.
+      // Otherwise, pick a random file/opeartion to run.
+      if(syncQueue.current) {
+        currentPath = syncQueue.current.path;
+        currentOperation = syncQueue.current.operation;
+        logger("SyncManager", "restarting cached sync", currentPath, currentOperation);
+        runCurrent();
+      } else {
+        selectCurrent(syncQueue);
+      }
+    }
+
+    Project.getSyncQueue(pickCurrentOperation);
+  };
+
+  SyncManager.prototype.setSyncing = function(value) {
+    // When we flip from not-syncing to syncing, emit an event
+    if(!this.syncing && value) {
+      logger("SyncManager", "start syncing");
+      this.trigger("sync-start");
+    }
+
+    this.syncing = value;
+
+    // Also tell interested users of SyncManager that we're starting/stopping
+    // an AJAX sync for a particular file (vs. entire sync process).
+    if(value) {
+      this.trigger("file-sync-start");
+    } else {
+      this.trigger("file-sync-stop");
+    }
+  };
+  SyncManager.prototype.isSyncing = function() {
+    return !!this.syncing;
+  };
+  SyncManager.prototype.sync = function() {
+    // If we're already in the process of syncing, bail
+    if(this.isSyncing()) {
+      return;
+    }
+    this.runNextOperation();
+  };
+
+  return SyncManager;
+});

--- a/public/editor/scripts/editor/js/fc/sync-state.js
+++ b/public/editor/scripts/editor/js/fc/sync-state.js
@@ -1,9 +1,12 @@
-define(function() {
+/**
+ * Manage a warning on application close depending on whether we're
+ * currently syncing (file sync or publish) with the server or not.
+ */
 
-  var _registeredFns = {
-    syncing: [],
-    completed: []
-  };
+define(function(require) {
+
+  var EventEmitter = require("EventEmitter");
+  var SyncState = new EventEmitter();
 
   function _onbeforeunload(e) {
     var s = "Sync in progress...";
@@ -16,37 +19,19 @@ define(function() {
     return s;
   }
 
-  function _trigger(type) {
-    _registeredFns[type].forEach(function(fn) { fn(); });
-  }
-
-  function isSyncing() {
+  SyncState.isSyncing = function() {
     return !!window.onbeforeunload;
-  }
-
-  function onSyncing(fn) {
-    _registeredFns.syncing.push(fn);
-  }
-
-  function syncing() {
-    window.onbeforeunload = _onbeforeunload;
-    _trigger("syncing");
-  }
-
-  function completed() {
-    window.onbeforeunload = null;
-    _trigger("completed");
-  }
-
-  function onCompleted(fn) {
-    _registeredFns.completed.push(fn);
-  }
-
-  return {
-    isSyncing: isSyncing,
-    syncing: syncing,
-    onSyncing: onSyncing,
-    completed: completed,
-    onCompleted: onCompleted
   };
+
+  SyncState.syncing = function() {
+    window.onbeforeunload = _onbeforeunload;
+    SyncState.trigger("syncing");
+  };
+
+  SyncState.completed = function() {
+    window.onbeforeunload = null;
+    SyncState.trigger("completed");
+  };
+
+  return SyncState;
 });

--- a/public/editor/scripts/logger.js
+++ b/public/editor/scripts/logger.js
@@ -1,0 +1,31 @@
+/**
+ * Simple console logging. To enable logging, use ?logging=1
+ */
+
+define(function() {
+
+  function log(module, data) {
+    var args = Array.prototype.slice.call(arguments);
+
+    if(args.length === 1) {
+      data = module;
+      module = "Thimble LOG";
+    } else {
+      module = "Thimble LOG (module=" + args[0] + ")";
+      args.shift();
+    }
+
+    args.unshift("[" + module + "]");
+    console.log.apply(console, args);
+  }
+
+  function noop() {}
+
+  return (function(search) {
+    if(search.indexOf("logging=1") > -1) {
+      return log;
+    }
+
+    return noop;
+  }(window.location.search));
+});

--- a/public/editor/scripts/main.js
+++ b/public/editor/scripts/main.js
@@ -4,12 +4,15 @@ require.config({
   paths: {
     "bowser": "/resources/scripts/vendor/bowser",
     "sso-override": "../../sso-override",
+    "logger": "../../logger",
     "jquery": "/bower/jquery/index",
     "localized": "/bower/webmaker-i18n/localized",
     "uuid": "/bower/node-uuid/uuid",
     "cookies": "/bower/cookies-js/dist/cookies",
     "project": "../../project/project",
-    "constants": "../../constants"
+    "PathCache": "../../path-cache",
+    "constants": "../../constants",
+    "EventEmitter": "/bower/eventEmitter/EventEmitter.min"
   },
   shim: {
     "jquery": {
@@ -24,7 +27,7 @@ require(["jquery", "bowser"], function($, bowser) {
   if((bowser.msie && bowser.version < 11) || (bowser.safari && bowser.version < 8)) {
     $("#browser-support-warning").removeClass("hide");
 
-    $(".let-me-in").on("click", function(e) {
+    $(".let-me-in").on("click", function() {
       $("#browser-support-warning").fadeOut();
       return false;
     });

--- a/public/editor/scripts/path-cache.js
+++ b/public/editor/scripts/path-cache.js
@@ -1,0 +1,114 @@
+/**
+ * The PathCache is an in-memory cache of paths and operations to be performed
+ * on them (i.e., update, delete).  These operations need to get added to the
+ * SyncQueue and eventually run by the SyncManager.  The PathCache is temporary
+ * storage for these until they can be processed.  The PathCache also takes care
+ * of reading/writing these operations to storage between loads of the page, in
+ * the case that they haven't been processed yet.
+ */
+
+define(function(require) {
+  var Constants = require("constants");
+  var logger = require("logger");
+
+  var SYNC_OPERATION_UPDATE = Constants.SYNC_OPERATION_UPDATE;
+  var SYNC_OPERATION_DELETE = Constants.SYNC_OPERATION_DELETE;
+
+  var items;
+
+  // Decide between an update and delete operation, depending on previous operations.
+  function mergeOperations(previous, requested) {
+    // If there is no pending sync operation, or the new one is the same
+    // (update followed by update), just return the new one.
+    if(!previous || previous === requested) {
+      return requested;
+    }
+
+    // A delete trumps a pending update (we can skip a pending update if we'll just delete later)
+    if(previous === SYNC_OPERATION_UPDATE && requested === SYNC_OPERATION_DELETE) {
+      return SYNC_OPERATION_DELETE;
+    }
+
+    // An update trumps a pending delete (we can just update the old contents with new)
+    if(previous === SYNC_OPERATION_DELETE && requested === SYNC_OPERATION_UPDATE) {
+      return SYNC_OPERATION_UPDATE;
+    }
+
+    // Should never hit this, but if we do, default to an update
+    console.log("[Thimble Error] unexpected sync states, defaulting to update:", previous, requested);
+    return SYNC_OPERATION_UPDATE;
+  }
+
+  /**
+   * The cache is an in-memory, localStorage-backed array of paths + operations to be
+   * synced. It gets merged with the sync queue on a regular basis (i.e., written to
+   * disk). We use it so that we don't have two separate writes to the sync queue.
+   */
+  function init(projectRoot) {
+    items = [];
+
+    // Read/write to a key specific to this project's root
+    var key = Constants.CACHE_KEY_PREFIX + projectRoot;
+
+    if(!window.localStorage) {
+      return;
+    }
+
+    // Register to save any in-memory cache operations before we close
+    window.addEventListener("unload", function() {
+      if(!items.length) {
+        return;
+      }
+
+      localStorage.setItem(key, JSON.stringify(items));
+    });
+
+    var prev = localStorage.getItem(key);
+    if(!prev) {
+      return;
+    }
+
+    // Read any cached operations out of storage
+    localStorage.removeItem(key);
+    try {
+      items = items.concat(JSON.parse(prev));
+      logger("project", "initialized file operations cache from storage (" + items.length + " operations)");
+    } catch(e) {
+      logger("project", "failed to initialize cached file operations from storage", prev);
+    }
+  }
+
+  // Add a path and operation item to the cache
+  function addItem(path, operation) {
+    items.push({
+      path: path,
+      operation: operation
+    });
+  }
+
+  /**
+   * Take all cached path operations and transfer them to the SyncQueue so that
+   * they can be processed and run.
+   */
+  function transferToSyncQueue(syncQueue) {
+    // Migrate cached items to sync queue
+    items.forEach(function(item) {
+      var path = item.path;
+      var operation = item.operation;
+
+      var previous = syncQueue.pending[path] || null;
+      syncQueue.pending[path] = mergeOperations(previous, operation);
+    });
+
+    // Clear all cached items
+    items.length = 0;
+
+    return syncQueue;
+  }
+
+  return {
+    init: init,
+    addItem: addItem,
+    transferToSyncQueue: transferToSyncQueue
+  };
+});

--- a/public/editor/scripts/project/remote.js
+++ b/public/editor/scripts/project/remote.js
@@ -1,17 +1,19 @@
 define(function(require) {
   var Constants = require("constants");
+  var SYNC_OPERATION_DELETE = require("constants").SYNC_OPERATION_DELETE;
   var Path = Bramble.Filer.Path;
   var Buffer = Bramble.Filer.Buffer;
   var fs = Bramble.getFileSystem();
 
   // Installs a tarball (arraybuffer) containing the project's files/folders.
-  function installTarball(root, tarball, callback) {
+  function installTarball(config, tarball, callback) {
     var untarWorker;
     var pending = null;
     var sh = new fs.Shell();
+    var root = config.root;
+    var pendingOperations = config.syncQueue.pending;
 
     function extract(path, data, callback) {
-      path = Path.join(root, path);
       var basedir = Path.dirname(path);
 
       sh.mkdirp(basedir, function(err) {
@@ -21,6 +23,21 @@ define(function(require) {
 
         fs.writeFile(path, new Buffer(data), {encoding: null}, callback);
       });
+    }
+
+    // If there are pending delete operations to be run in the SyncQueue for a
+    // given path in the project (e.g., user deleted a file locally, but closed
+    // before the change could be synced to the server), we can safely ignore
+    // the initial extract, since we'll just delete the file soon anyway. 
+    function maybeExtract(path, data, callback) {
+      path = Path.join(root, path);
+
+      if(pendingOperations[path] === SYNC_OPERATION_DELETE) {
+        callback();
+        return;
+      }
+
+      extract(path, data, callback);
     }
 
     function finish(err) {
@@ -49,7 +66,7 @@ define(function(require) {
         // Set the total number of files we need to deal with so we know when we're done
         pending = data.totalFilesInArchive;
       } else if(data.type === "extract") {
-        extract(data.unarchivedFile.filename, data.unarchivedFile.fileData, writeCallback);
+        maybeExtract(data.unarchivedFile.filename, data.unarchivedFile.fileData, writeCallback);
       } else if(data.type === "error") {
         finish(new Error("[Thimble error]: " + data.msg));
       }
@@ -74,40 +91,16 @@ define(function(require) {
         return callback(new Error("[Thimble error] unable to get tarball, status was:", this.status));
       }
 
-      installTarball(config.root, this.response, callback);
+      installTarball(config, this.response, callback);
     };
     xhr.send();
   }
 
   function upgradeAnonymousProject(config, callback) {
-    var fsync = config.fsync;
     var shell = new fs.Shell();
     var oldRoot = Path.join(Constants.ANONYMOUS_USER_FOLDER, config.anonymousId.toString());
     var newRoot = config.root;
-
-    // We know we have to run shell.find and shell.rm before
-    // the callback can be fired for success, so we start at 2
-    // and increase by 1 for every file to be persisted asynchronously
-    // to the publish server
-    var pendingAsyncOperations = 2;
-    var callbackCalled = false;
-
-    function fireCallbackIfSafe(err) {
-      // We ensure an error is never swallowed
-      if (err && !callbackCalled) {
-        fsync.removeAfterEachCallback(fireCallbackIfSafe);
-        callbackCalled = true;
-        return callback(err);
-      }
-
-      // When all the operations are done, if we can safely
-      // call the callback we do so
-      if (--pendingAsyncOperations === 0 && !callbackCalled) {
-        fsync.removeAfterEachCallback(fireCallbackIfSafe);
-        callbackCalled = true;
-        callback();
-      }
-    }
+    var pathUpdatesCache = [];
 
     function upgradeFile(path, next) {
       if (path.match(/\/$/)) {
@@ -132,25 +125,30 @@ define(function(require) {
             if (err) {
               return next(err);
             }
-            pendingAsyncOperations++;
 
             // Track this as a file to be persisted to publish
-            fsync.handlers.change(newPath);
+            pathUpdatesCache.push(newPath);
             next();
           });
         });
       });
     }
 
-    fsync.addAfterEachCallback(fireCallbackIfSafe);
     shell.find(oldRoot, {exec: upgradeFile}, function(err) {
-      pendingAsyncOperations--;
-
       if (err) {
-        return fireCallbackIfSafe(err);
+        console.error("[Thimble Error] unable to process path while upgrading anonymous project", err);
+        return callback(err);
       }
 
-      shell.rm(oldRoot, {recursive: true}, fireCallbackIfSafe);
+      shell.rm(oldRoot, {recursive: true}, function(err) {
+        if(err) {
+          console.error("[Thimble Error] unable to remove path while upgrading anonymous project", err);
+          return callback(err);
+        }
+
+        // Send back the list of paths to be updated
+        callback(null, pathUpdatesCache);
+      });
     });
   }
 

--- a/public/homepage/scripts/main.js
+++ b/public/homepage/scripts/main.js
@@ -1,3 +1,5 @@
+/* global requirejs */
+
 // Because we pre-load require scripts needed by the editor, we need to
 // eat error messages related to fetching but not using those modules.
 requirejs.onError = function(err) {


### PR DESCRIPTION
This is untested, and not 100% complete.  But I think I'd like a review, since I didn't write any of the code I'm replacing.  I'm especially not sure about enabling/disabling the publish dialog.  I'm trying to move to using events instead of callbacks for the sync manager.  I can probably remove a bunch of stuff in that file, but I'm not sure yet.