### PR TITLE
Fix #1198 - Renaming the project triggers multiple requests

### DIFF
--- a/public/editor/scripts/editor/js/fc/bramble-input-field.js
+++ b/public/editor/scripts/editor/js/fc/bramble-input-field.js
@@ -93,12 +93,13 @@ define(function(require) {
   // Similar to JQuery's `.val()` method
   InputField.prototype.val = function() {
     // Extract the value from the <input> or <span> depending on input state
+    var method = this.mode === InputField.Modes.STATIC ? "text" : "val";
+
     if(arguments.length === 0) {
-      return this._element[this.mode === InputField.Modes.STATIC ? "text" : "val"]();
+      return this._element[method]();
     }
 
-    // Store the value as harmless text content
-    this._element.text(arguments[0]);
+    this._element[method](arguments[0]);
   };
 
   // The `id` of the field in the DOM

--- a/public/editor/scripts/editor/js/fc/project-rename.js
+++ b/public/editor/scripts/editor/js/fc/project-rename.js
@@ -9,18 +9,20 @@ define(function(require) {
     var titleBar = context.titleBar;
     var saveButton = context.saveButton;
 
-    function saveClicked(e) {
-        context.saveButton.off("click", saveClicked);
+    function saveClicked() {
+      // Ignore clicks if the button is disabled.
+      if(context.saveButton.hasClass("disabled")) {
+        return false;
+      }
 
-        e.stopPropagation();
-        e.preventDefault();
-        save(context);
+      context.saveButton.off("click", saveClicked);
+      save(context);
+      return false;
     }
 
-    function textClicked(e) {
-        e.stopPropagation();
-        e.preventDefault();
-        rename(context);
+    function textClicked() {
+      rename(context);
+      return false;
     }
 
     saveButton[isSave ? "hide" : "show"]();
@@ -47,6 +49,9 @@ define(function(require) {
           save(context);
         }),
         esc: new KeyHandler.ESC(container, function() {
+          // Restore the current title if ESC is pressed
+          context.titleBar.val(Project.getTitle());
+
           context.saveButton.off("click", saveClicked);
           editingComplete(context);
         }),
@@ -54,10 +59,8 @@ define(function(require) {
           var input = context.titleBar;
           var nameLength = input.val().length;
 
-          //add or remove the 'disabled' class based on if length is 0
-          //and also add or remove the click listener
+          // Add or remove the 'disabled' class based on title length
           context.saveButton[nameLength === 0 ? "addClass" : "removeClass"]("disabled");
-          context.saveButton[nameLength === 0 ? "off" : "on"]("click", saveClicked);
         })
       };
 


### PR DESCRIPTION
This fixes a few bugs:
* we were adding/removing (and mostly adding) the click handler over and over when the any key handler ran.  Instead of doing this, I just add it once, then ignore it if the button is disabled when it fires
* I've fixed the esc key handling so that it restores the title as it was before editing began. This includes both the 0 length string case, and also all other cases.
* to fix the above, I had to fix a bug in the input field, where it wouldn't set the proper attribute on both an `input` and `span`.

Testing this now only gives me 1 request for both the `enter` case and also the `click` of the Save button.  I also find the esc key does what I expect.

@gideonthomas r?