### PR TITLE
Fix #1196 - add UI for enabling/disabling automatic JS execution in the preview

### DIFF
--- a/public/editor/scripts/editor/js/fc/bramble-menus.js
+++ b/public/editor/scripts/editor/js/fc/bramble-menus.js
@@ -43,6 +43,24 @@ define(function(require) {
     setWordWrapUI(bramble.getWordWrap());
 
 
+    // Enable/Disable JavaScript in Preview
+    $("#allow-scripts-toggle").click(function() {
+      // Toggle current value
+      var $allowScriptsToggle = $("#allow-scripts-toggle");
+      var toggle = !($allowScriptsToggle.hasClass("switch-enabled"));
+
+      if(toggle) {
+        $allowScriptsToggle.addClass("switch-enabled");
+        bramble.enableJavaScript();
+      } else {
+        $allowScriptsToggle.removeClass("switch-enabled");
+        bramble.disableJavaScript();
+      }
+
+      return false;
+    });
+
+
     // Theme Toggle
     function lightThemeUI() {
       var transitionSpeed = 200;

--- a/views/editor/nav-options.html
+++ b/views/editor/nav-options.html
@@ -83,6 +83,13 @@
                   <div class="toggle-button"></div>
                 </div>
               </li>
+              <li>
+                <span>Allow JavaScript</span>
+                <div title="Toggle running JavaScript code in the preview" class="switch-toggle switch-enabled" id="allow-scripts-toggle">
+                  <div class="toggle-backing"></div>
+                  <div class="toggle-button"></div>
+                </div>
+              </li>
             </ul>
           </div>
       </div>


### PR DESCRIPTION
This adds UI to toggle automatic JS execution in the preview on/off.  We've had support for this in Bramble since the beginning, but never bothered to do UI.  I think it's pretty useful when you're doing large JS projects and want to block re-running JS on every refresh.

I'm not sure of the best wording: "Allow JavaScript" vs. "Autorun JavaScript" vs. ...?

NOTE: this is a runtime option vs. something we save in your overall preferences, since it's pretty specific to a particular project, and I think liable to confuse users if we disable it by default on startup.

r? @gideonthomas, @flukeout 