### PR TITLE
Hide published details bar when on mobile phones without enough room

### DIFF
--- a/public/resources/remix/index.js
+++ b/public/resources/remix/index.js
@@ -17,7 +17,8 @@ var detailsBarHtml =
 function customizeScroll($) {
   var bodyEl = $("body");
   var detailsBar = $(".remix-details-bar");
-  var detailsBarHeight = 64;
+  // If the remix details bar is not visible, don't add padding
+  var detailsBarHeight = detailsBar.is(":visible") ? detailsBar.height() : 0;
   var currentPadding = parseInt(bodyEl.css("padding-top"));
   bodyEl.css("padding-top", currentPadding + detailsBarHeight);
 

--- a/public/resources/remix/style.less
+++ b/public/resources/remix/style.less
@@ -147,3 +147,10 @@
     transform: translateY(0px);
   }
 }
+
+/* Deal with smaller screens not having room for details bar */
+@media only screen and (min-device-width : 320px) and (max-device-width : 480px) {
+  .remix-details-bar {
+    display: none !important;
+  }
+}


### PR DESCRIPTION
@flukeout, see if this is good enough for now, so we don't crowd out the page content on a mobile phone.