### PR TITLE
Deal with remix stylesheet loading after padding on body already applied for remix bar

### DIFF
--- a/public/resources/remix/index.js
+++ b/public/resources/remix/index.js
@@ -17,8 +17,8 @@ var detailsBarHtml =
 function customizeScroll($) {
   var bodyEl = $("body");
   var detailsBar = $(".remix-details-bar");
-  // If the remix details bar is not visible, don't add padding
-  var detailsBarHeight = detailsBar.is(":visible") ? detailsBar.height() : 0;
+  // If we're on a small screen (480px == phone in landscape), don't add padding
+  var detailsBarHeight = window.innerWidth >= 480 ? detailsBar.height() : 0;
   var currentPadding = parseInt(bodyEl.css("padding-top"));
   bodyEl.css("padding-top", currentPadding + detailsBarHeight);
 

--- a/public/resources/remix/style.less
+++ b/public/resources/remix/style.less
@@ -149,7 +149,7 @@
 }
 
 /* Deal with smaller screens not having room for details bar */
-@media only screen and (min-device-width : 320px) and (max-device-width : 480px) {
+@media only screen and (min-device-width : 480px) {
   .remix-details-bar {
     display: none !important;
   }


### PR DESCRIPTION
I tested the fix on staging, and it's not quite right.  The padding won't get dealt with for small screens, because the check for the remix details bar being visibile is always going to return true, since the stylesheet will be loaded already.

This changes things to instead use the window width.  I've also fixed a bug that caused the wrong style to get applied to mobile screens in portrait.