### PR TITLE
Fix #1241 - Stop Thimble (client) from DDoS'ing Thimble/Publish servers

### DIFF
--- a/public/editor/scripts/constants.js
+++ b/public/editor/scripts/constants.js
@@ -4,8 +4,16 @@ define(function() {
     PROJECT_META_KEY: "thimble-project-meta",
     SYNC_OPERATION_UPDATE: "update",
     SYNC_OPERATION_DELETE: "delete",
+    // Default amount of time (ms) to wait between successful AJAX operations
+    AJAX_DEFAULT_DELAY_MS: 10,
+    // Default timeout period for AJAX requests so .fail() always gets called
+    AJAX_DEFAULT_TIMEOUT_MS: 30 * 1000,
     // Timer for how often to empty the sync queue if not explicitly asked to do so
-    SYNC_TIMEOUT_MS: 10 * 1000,
+    AUTOSYNC_INTERVAL_MS: 60 * 1000,
+    // Base unit of MS to apply to each backoff exponent period
+    BACKOFF_BASE_MS: 200,
+    // Maximum delay to backoff between failed network requests
+    BACKOFF_MAX_DELAY_MS: 20 * 1000,
     CACHE_KEY_PREFIX: "thimble-cache-key-"
   };
 });

--- a/public/editor/scripts/editor/js/fc/backoff.js
+++ b/public/editor/scripts/editor/js/fc/backoff.js
@@ -1,0 +1,27 @@
+/**
+ * Determine a backoff delay (ms) to wait before running the next
+ * network operation. Inspired by https://github.com/awslabs/aws-arch-backoff-simulator/blob/master/src/backoff_simulator.py
+ */
+define(function(require) {
+  var BACKOFF_BASE_MS = require("constants").BACKOFF_BASE_MS;
+  var BACKOFF_MAX_DELAY_MS = require("constants").BACKOFF_MAX_DELAY_MS;
+
+  // Returns a random integer between min (included) and max (included)
+  // Using Math.round() will give you a non-uniform distribution!
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/random
+  function _getRandomIntInclusive(min, max) {
+    return Math.floor(Math.random() * (max - min + 1)) + min;
+  }
+
+  function Backoff() {
+    this.iter = 0;
+  }
+
+  Backoff.prototype.next = function() {
+    this.iter++;
+    var v = Math.min(BACKOFF_BASE_MS * Math.pow(2, this.iter), BACKOFF_MAX_DELAY_MS);
+    return _getRandomIntInclusive(0, v);
+  };
+
+  return Backoff;
+});

--- a/public/editor/scripts/editor/js/fc/filesystem-sync.js
+++ b/public/editor/scripts/editor/js/fc/filesystem-sync.js
@@ -36,10 +36,15 @@ define(function(require) {
 
     // Update the UI with a "Saving..." indicator whenever we sync a file
     syncManager.on("file-sync-start", function() {
+      $("#navbar-save-indicator").text("Saving...");
       $("#navbar-save-indicator").removeClass("hide");
     });
     syncManager.on("file-sync-stop", function() {
       $("#navbar-save-indicator").addClass("hide");
+    });
+    syncManager.on("file-sync-error", function() {
+      // Saving over the network failed, let the user know, and that we'll retry
+      $("#navbar-save-indicator").text("Saving failed, retrying...");
     });
 
     // Warn the user when we're syncing so they don't close the window by accident

--- a/public/editor/scripts/editor/js/fc/project-rename.js
+++ b/public/editor/scripts/editor/js/fc/project-rename.js
@@ -3,6 +3,7 @@ define(function(require) {
   var InputField = require("fc/bramble-input-field");
   var KeyHandler = require("fc/bramble-keyhandler");
   var Project = require("project");
+  var AJAX_DEFAULT_TIMEOUT_MS = require("constants").AJAX_DEFAULT_TIMEOUT_MS;
 
   function toggleComponents(context, isSave) {
     var container = context.container;
@@ -87,7 +88,8 @@ define(function(require) {
       url: appUrl + "/projects/" + Project.getID() + "/rename",
       data: JSON.stringify({
         title: title
-      })
+      }),
+      timeout: AJAX_DEFAULT_TIMEOUT_MS
     });
     request.done(function(data) {
       if(request.status !== 200) {
@@ -98,6 +100,7 @@ define(function(require) {
       callback();
     });
     request.fail(function(jqXHR, status, err) {
+      err = err || new Error("unknown network error");
       callback(err);
     });
   }

--- a/public/editor/scripts/editor/js/fc/sync-manager.js
+++ b/public/editor/scripts/editor/js/fc/sync-manager.js
@@ -35,9 +35,12 @@ define(function(require) {
   var EventEmitter = require("EventEmitter");
   var SYNC_OPERATION_UPDATE = require("constants").SYNC_OPERATION_UPDATE;
   var SYNC_OPERATION_DELETE = require("constants").SYNC_OPERATION_DELETE;
-  var SYNC_TIMEOUT_MS = require("constants").SYNC_TIMEOUT_MS;
+  var AUTOSYNC_INTERVAL_MS = require("constants").AUTOSYNC_INTERVAL_MS;
+  var AJAX_DEFAULT_DELAY_MS = require("constants").AJAX_DEFAULT_DELAY_MS;
+  var AJAX_DEFAULT_TIMEOUT_MS = require("constants").AJAX_DEFAULT_TIMEOUT_MS;
   var Project = require("project");
   var PathCache = require("PathCache");
+  var Backoff = require("fc/backoff");
   var logger = require("logger");
 
   // SyncManager instance
@@ -79,33 +82,31 @@ define(function(require) {
     return _instance;
   };
 
-  // Start the autosync interval.
+  // Start auto-syncing.
   SyncManager.prototype.start = function() {
     if(this._interval) {
       return;
     }
-    this._interval = setInterval(this.sync.bind(this), SYNC_TIMEOUT_MS);
+    // Schedule future syncing
+    this._interval = setInterval(this.sync.bind(this), AUTOSYNC_INTERVAL_MS);
+    // And also do one now
+    this.sync();
   };
 
   SyncManager.prototype.emitProgressEvent = function() {
     var pendingCount = this.pendingCount;
 
-     // Emit either a `complete` event or a `pending` event depending on queue length.
-    if(pendingCount === 0) {
-      logger("SyncManager", "complete event");
-      this.trigger("complete");
-    } else {
-      logger("SyncManager", "progress event - pending paths to sync:", pendingCount);
-      this.trigger("progress", [pendingCount]);
-    }
+    logger("SyncManager", "progress event - pending paths to sync:", pendingCount);
+    this.trigger("progress", [pendingCount]);
+  };
+  SyncManager.prototype.emitCompleteEvent = function() {
+    logger("SyncManager", "complete event");
+    this.trigger("complete");
   };
   SyncManager.prototype.emitErrorEvent = function(err) {
     this.setSyncing(false);
     this.trigger("error", [err]);
     logger("SyncManager", "error event", err);
-
-    // Try running the operation again, or the next one at least
-    this.runNextOperation();
   };
 
   SyncManager.prototype.setPendingCount = function(syncQueue) {
@@ -129,7 +130,8 @@ define(function(require) {
       url: Project.getHost() + "/projects/" + Project.getID() + "/files",
       cache: false,
       contentType: false,
-      processData: false
+      processData: false,
+      timeout: AJAX_DEFAULT_TIMEOUT_MS
     };
 
     function send(id) {
@@ -149,6 +151,7 @@ define(function(require) {
         Project.setFileID(path, data.id, callback);
       });
       request.fail(function(jqXHR, status, err) {
+        err = err || new Error("unknown network error during update operation");
         logger("SyncManager", "unable to persist the file update to the server", err);
         callback(err);
       });
@@ -186,6 +189,7 @@ define(function(require) {
         },
         type: "DELETE",
         url: Project.getHost() + "/projects/" + Project.getID() + "/files/" + id + "?dateUpdated=" + (new Date()).toISOString(),
+        timeout: AJAX_DEFAULT_TIMEOUT_MS
       });
       request.done(function() {
         if(request.status !== 200) {
@@ -195,6 +199,7 @@ define(function(require) {
         finish();
       });
       request.fail(function(jqXHR, status, err) {
+        err = err || new Error("unknown network error during delete operation");
         logger("SyncManager", "unable to persist the file delete to the server", err);
         callback(err);
       });
@@ -236,10 +241,15 @@ define(function(require) {
         }
 
         function finish() {
-          // Operation synced successfully, remove it and save the SyncQueue.
+          // Current operation finished, remove it and save the SyncQueue.
           delete syncQueue.current;
 
+          // Add any recent/failed (re-queued) operations to the queue
+          syncQueue = PathCache.transferToSyncQueue(syncQueue);
+
           Project.setSyncQueue(syncQueue, function(err) {
+            var delay;
+
             if(err) {
               self.emitErrorEvent(err);
               return;
@@ -247,11 +257,18 @@ define(function(require) {
 
             self.setPendingCount(syncQueue);
 
-            // If there are more files to sync, run the next one
+            // If there are more files to sync, run the next one.
             if(self.getPendingCount() > 0) {
-              self.runNextOperation();
+              self.emitProgressEvent();
+
+              // If the last operation errored, apply a backoff delay.
+              delay = (self.backoff && self.backoff.next()) || AJAX_DEFAULT_DELAY_MS;
+
+              logger("SyncManager", "finished current operation (" + (ajaxError ? "failed" : "success") + "), will run next in " + delay + "ms. " + self.getPendingCount() + " operation(s) remain.");
+              setTimeout(self.runNextOperation.bind(self), delay);
             } else {
               self.setSyncing(false);
+              self.emitCompleteEvent();
             }
           });
         }
@@ -267,9 +284,17 @@ define(function(require) {
         }
 
         // If the network operation errored, put this file operation back in the pending list
+        // and create a backoff delay object.  If it worked, remove a previous backoff delay (if any).
         if(ajaxError) {
           logger("SyncManager", "error syncing file, requeuing operation", ajaxError);
+          self.trigger("file-sync-error");
           queueOperation();
+
+          if(!self.backoff) {
+            self.backoff = new Backoff();
+          }
+        } else {
+          delete self.backoff;
         }
 
         finish();
@@ -286,7 +311,6 @@ define(function(require) {
       } else {
         self.emitErrorEvent(new Error("[Thimble Error] unknown sync operation:" + currentOperation));
       }
-      self.emitProgressEvent();
     }
 
     function selectCurrent(syncQueue) {
@@ -297,7 +321,7 @@ define(function(require) {
       // If there are no pending paths to sync, we're done.
       if(self.pendingCount === 0) {
         logger("SyncManager", "no pending sync operations, stopping syncing.");
-        self.emitProgressEvent();
+        self.emitCompleteEvent();
         self.setSyncing(false);
         return;
       }

--- a/public/editor/scripts/open-project.js
+++ b/public/editor/scripts/open-project.js
@@ -9,7 +9,7 @@ require.config({
   }
 });
 
-require(["jquery"], function($) {
+require(["jquery", "constants"], function($, Constants) {
   var projects = document.querySelectorAll("tr.bramble-user-project");
   var username = encodeURIComponent($("#project-list").attr("data-username"));
   var queryString = window.location.search;
@@ -73,7 +73,8 @@ require(["jquery"], function($) {
         "X-Csrf-Token": $("meta[name='csrf-token']").attr("content")
       },
       type: "DELETE",
-      url: "/projects/" + projectId
+      url: "/projects/" + projectId,
+      timeout: Constants.AJAX_DEFAULT_TIMEOUT_MS
     });
     request.done(function() {
       if(request.status !== 204) {
@@ -81,6 +82,7 @@ require(["jquery"], function($) {
       }
     });
     request.fail(function(jqXHR, status, err) {
+      err = err || new Error("unknown network error");
       console.error(err);
     });
 

--- a/public/editor/scripts/project/metadata.js
+++ b/public/editor/scripts/project/metadata.js
@@ -1,6 +1,7 @@
 define(function(require) {
   var $ = require("jquery");
   var PROJECT_META_KEY = require("constants").PROJECT_META_KEY;
+  var AJAX_DEFAULT_TIMEOUT_MS = require("constants").AJAX_DEFAULT_TIMEOUT_MS;
   var fs = Bramble.getFileSystem();
 
   // We only want one operation at a time on the metadata xattrib.
@@ -245,12 +246,14 @@ define(function(require) {
       headers: {
         "Accept": "application/json"
       },
-      url: url
+      url: url,
+      timeout: AJAX_DEFAULT_TIMEOUT_MS
     });
     request.done(function(data) {
       callback(null, data);
     });
     request.fail(function(jqXHR, status, err) {
+      err = err || new Error("unknown network error");
       callback(err);
     });
   }
@@ -307,12 +310,14 @@ define(function(require) {
         "X-Csrf-Token": config.csrfToken
       },
       url: config.host + "/projects/" + config.id,
-      data: JSON.stringify(config.data)
+      data: JSON.stringify(config.data),
+      timeout: AJAX_DEFAULT_TIMEOUT_MS
     });
     request.done(function() {
       callback();
     });
     request.fail(function(jqXHR, status, err) {
+      err = err || new Error("unknown network error");
       callback(err);
     });
   }


### PR DESCRIPTION
This patch greatly improves our performance when the network or server go down, or when the server is under heavy load.  When an update or delete network operation fails, this adds some delay before retrying it.  Previously, we just tried again right away, and if the server was under load, we'd just do that over and over in a tight loop forever, which will kill the server with enough clients all doing it at once.

This also fixes a bug where we incorrectly thought we'd completed a sync if the server went down (i.e., `net::ERR_CONNECTION_REFUSED` vs. a `500` response).  This would mean that we could lose track of files that need to get synced in the event of a crashed server.

This also provides a bit of UI indication to the user when saving fails, letting them know and that it is being retried.

There are a few things I'd like advice on, though:
* are my numbers right?  I'm doing autosync intervals of 15ms, and a failure backoff delay of 1-20s.  For the most part a user is unaware of server syncing, and everything gets saved to the local db almost instantly (i.e., we aren't in a rush to get it on the server).
* I was going to do something fancy with [exponential backoff with jitter](http://www.awsarchitectureblog.com/2015/03/backoff.html), but in the end just chose a random Nms between 1000ms and 20,000ms.  My thinking is that this spreads out the load across 20s time slices with many simultaneous clients.  Is there something smarter I could do?

If you want to test this, just kill the publish (will cause a `500`) or thimble (will cause a connection refused error) servers while it's running or in the middle of a sync. With this patch, the servers can come and go without any data loss or increased load from the client.  Running it with `?logging=1` will give lots of info on the console. 

r? @gideonthomas, and also @Pomax and @jbuck on the higher level thinking + numbers I chose.