### PR TITLE
Fix #975 - Thimble doesn't remember my theme settings

### DIFF
--- a/public/editor/scripts/editor/js/fc/bramble-menus.js
+++ b/public/editor/scripts/editor/js/fc/bramble-menus.js
@@ -109,13 +109,12 @@ define(function(require) {
     $("#theme-light").click(toggleTheme);
     $("#theme-dark").click(toggleTheme);
 
-    var previousTheme = bramble.getTheme();
-    if(previousTheme) {
-      if(previousTheme === "light-theme") {
-        lightThemeUI();
-      } else if(previousTheme === "dark-theme") {
-        darkThemeUI();
-      }
+    // If the user explicitly set the light-theme last time, use that
+    // otherwise default to using the dark-theme.
+    if(bramble.getTheme() === "light-theme") {
+      setTheme("light-theme");
+    } else {
+      setTheme("dark-theme");
     }
   }
 


### PR DESCRIPTION
This simplifies the code that figures out what we should do on startup, and forces bramble into the right state no matter what.  I can't reproduce the theme problem anymore with this patch.

r? @gideonthomas 