### PR TITLE
Don't crash when loading over low-bandwidth networks, part of #1224

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -14,6 +14,7 @@ module.exports = function( grunt ) {
      requirejs: {
       dist: {
         options: {
+          waitSeconds: 120,
           appDir: "./public/editor/scripts/",
           baseUrl: "./editor/js",
           dir: "./dist",

--- a/public/editor/scripts/main.js
+++ b/public/editor/scripts/main.js
@@ -1,5 +1,6 @@
 // NOTE: if you change this, update Gruntfile's requirejs:dist task too
 require.config({
+  waitSeconds: 120,
   baseUrl: "/editor/scripts/editor/js",
   paths: {
     "bowser": "/resources/scripts/vendor/bowser",

--- a/public/editor/scripts/open-project.js
+++ b/public/editor/scripts/open-project.js
@@ -1,4 +1,5 @@
 require.config({
+  waitSeconds: 120,
   paths: {
     "jquery": "/bower/jquery/index"
   },

--- a/public/homepage/scripts/main.js
+++ b/public/homepage/scripts/main.js
@@ -9,6 +9,7 @@ requirejs.onError = function(err) {
 };
 
 require.config({
+  waitSeconds: 120,
   baseUrl: "/homepage/scripts",
   paths: {
     "jquery": "/bower/jquery/index",


### PR DESCRIPTION
If not instructed to do otherwise, requirejs will timeout module loading after 7s.  Based on similar bugs and fixes in other code, I've set our Thimble timeout to be 2 mins.  I'm going to do a similar fix in Bramble. 