### PR TITLE
Removing flex rule for steps list to fix styling bugs.

### DIFF
--- a/public/resources/tutorial/tutorial.css
+++ b/public/resources/tutorial/tutorial.css
@@ -73,8 +73,6 @@ ol.steps > li {
   position: relative;
   margin: 0 0 35px 0;
   min-height: 45px;
-  display: flex;
-  align-items:center;
 }
 
 ol.steps > li h6 {


### PR DESCRIPTION
I originally added this to fix the styling of the steps list for when it has unrealistically short content, which never really happens. This removes that attempt which also clears some terrible unexpected results like in the bug listed below.

Fixes #1309 