### PR TITLE
Expose language list to templates

### DIFF
--- a/server/localize.js
+++ b/server/localize.js
@@ -39,7 +39,13 @@ module.exports = function localize(server, options) {
     res.redirect(307, localizedUrl);
   });
 
-  server.locals.languages = webmakerI18N.getSupportLanguages();
+  let allLanguages = webmakerI18N.getAllLocaleCodes();
+  let languages = {};
+  webmakerI18N.getSupportLanguages().forEach(locale => {
+    languages[locale] = allLanguages[locale];
+  });
+  
+  server.locals.languages = languages;
 
   server.get("/strings/:lang?", webmakerI18N.stringsRoute("en-US"));
 };

--- a/server/routes/main/editor.js
+++ b/server/routes/main/editor.js
@@ -58,6 +58,7 @@ module.exports = function(config, req, res) {
 
   var options = {
     appURL: config.appURL,
+    languages: req.app.locals.languages,
     csrf: req.csrfToken(),
     editorHOST: config.editorHOST,
     loginURL: config.appURL + "/" + locale + "/login",

--- a/server/routes/main/editor.js
+++ b/server/routes/main/editor.js
@@ -58,6 +58,7 @@ module.exports = function(config, req, res) {
 
   var options = {
     appURL: config.appURL,
+    URL_PATHNAME: req.originalUrl.slice(req.originalUrl.indexOf("/", 1)),
     languages: req.app.locals.languages,
     csrf: req.csrfToken(),
     editorHOST: config.editorHOST,

--- a/server/routes/main/homepage.js
+++ b/server/routes/main/homepage.js
@@ -30,7 +30,8 @@ module.exports = function(config, req, res) {
     sixWordSummerKitUrl: env.get("SIX_WORD_SUMMER_KIT_URL"),
     loginURL: config.appURL + "/" + locale + "/login",
     editorHOST: config.editorHOST,
-    editorURL: config.editorURL
+    editorURL: config.editorURL,
+    languages: req.app.locals.languages
   };
 
   if (req.user) {

--- a/server/routes/main/homepage.js
+++ b/server/routes/main/homepage.js
@@ -31,6 +31,7 @@ module.exports = function(config, req, res) {
     loginURL: config.appURL + "/" + locale + "/login",
     editorHOST: config.editorHOST,
     editorURL: config.editorURL,
+    URL_PATHNAME: "/" + qs,
     languages: req.app.locals.languages
   };
 

--- a/server/routes/projects/read.js
+++ b/server/routes/projects/read.js
@@ -51,6 +51,7 @@ module.exports = function(config, req, res) {
     });
 
     var options = {
+      languages: req.app.locals.languages,
       csrf: req.csrfToken ? req.csrfToken() : null,
       HTTP_STATIC_URL: "/" + locale,
       username: user.username,

--- a/server/routes/projects/read.js
+++ b/server/routes/projects/read.js
@@ -52,6 +52,7 @@ module.exports = function(config, req, res) {
 
     var options = {
       languages: req.app.locals.languages,
+      URL_PATHNAME: "/projects" + qs,
       csrf: req.csrfToken ? req.csrfToken() : null,
       HTTP_STATIC_URL: "/" + locale,
       username: user.username,


### PR DESCRIPTION
@flukeout try rebasing against this branch or just use this code.

I think the nunjucks code for this will look something like:
```
{% for langCode, obj in languages %}
   <a href="/{{ langCode }}/whatever">{{ obj.nativeName }}</a>
{% endfor %}
```

Let me know if that works